### PR TITLE
Fix: basePath of app/docs should be empty string to be able to run on local

### DIFF
--- a/apps/docs/next.config.js
+++ b/apps/docs/next.config.js
@@ -2,7 +2,7 @@
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
-  basePath: process.env.BASE_PATH || '/',
+  basePath: process.env.BASE_PATH || '',
   images: {
     unoptimized: true,
   },


### PR DESCRIPTION
To fix this error: 
Error: Specified basePath /. basePath has to be either an empty string or a path prefix