### PR TITLE
fix: calendar not working properly in mobile

### DIFF
--- a/packages/react-compass/src/calendar/hooks/useCalendarCell.ts
+++ b/packages/react-compass/src/calendar/hooks/useCalendarCell.ts
@@ -144,11 +144,6 @@ export function useCalendarCell(
         return
       }
 
-      if (!('highlightedRange' in state)) {
-        state.selectDate?.(date)
-        state.setFocusedDate?.(date)
-      }
-
       if (
         'highlightedRange' in state &&
         !state.anchorDate &&

--- a/packages/react-compass/src/calendar/hooks/useDatePickerState.ts
+++ b/packages/react-compass/src/calendar/hooks/useDatePickerState.ts
@@ -100,7 +100,9 @@ export function useDatePickerState<T extends DateValue = DateValue>(
     }
 
     if (shouldClose) {
-      overlayState.setOpen(false)
+      setTimeout(() => {
+        overlayState.setOpen(false)
+      }, 0)
     }
   }
 

--- a/packages/react-compass/src/calendar/hooks/usePress.ts
+++ b/packages/react-compass/src/calendar/hooks/usePress.ts
@@ -95,6 +95,21 @@ function getTouchFromEvent(event: TouchEvent): Touch | null {
   return null
 }
 
+function getTouchById(
+  event: TouchEvent,
+  pointerId: null | number,
+): null | Touch {
+  const changedTouches = event.changedTouches
+  // eslint-disable-next-line @typescript-eslint/prefer-for-of
+  for (let i = 0; i < changedTouches.length; i++) {
+    const touch = changedTouches[i]
+    if (touch?.identifier === pointerId) {
+      return touch as Touch
+    }
+  }
+  return null
+}
+
 export function usePress(props: PressHookProps): PressResult {
   const {
     onPress,
@@ -645,10 +660,26 @@ export function usePress(props: PressHookProps): PressResult {
         if (!e.currentTarget.contains(e.target as Element)) {
           return
         }
-
         e.stopPropagation()
         if (!state.isPressed) {
           return
+        }
+
+        const touch = getTouchById(
+          e.nativeEvent as unknown as TouchEvent,
+          state.activePointerId as number,
+        )
+        if (
+          touch &&
+          isOverTarget(
+            touch as unknown as MouseEvent<FocusableElement>,
+            e.currentTarget,
+          )
+        ) {
+          triggerPressUp(e, state.pointerType)
+          triggerPressEnd(e, state.pointerType)
+        } else if (state.isOverTarget) {
+          triggerPressEnd(e, state.pointerType, false)
         }
 
         state.isPressed = false

--- a/packages/react-compass/src/calendar/hooks/useRangeCalendarState.ts
+++ b/packages/react-compass/src/calendar/hooks/useRangeCalendarState.ts
@@ -266,7 +266,7 @@ function makeRange(start: DateValue, end: DateValue): RangeValue<CalendarDate> {
 }
 
 function convertValue(newValue: CalendarDate, oldValue: DateValue) {
-  newValue = toCalendar(newValue, oldValue.calendar || new GregorianCalendar())
+  newValue = toCalendar(newValue, oldValue?.calendar || new GregorianCalendar())
 
   if (oldValue && 'hour' in oldValue) {
     return oldValue.set(newValue)


### PR DESCRIPTION
FIX: sometimes pointer event in mobile not working properly, `shouldCloseOnSelect` event passing through background element