### PR TITLE
[Chore] Refactor toggle using input state instead of react state

### DIFF
--- a/packages/react-compass/src/toggle/toggle.styles.ts
+++ b/packages/react-compass/src/toggle/toggle.styles.ts
@@ -17,6 +17,10 @@ export const StyledToggle = styled('div', {
     borderRadius: '$full',
     backgroundColor: '$background',
   },
+  input: {
+    visibility: 'hidden',
+    position: 'absolute',
+  },
   variants: {
     active: {
       true: {

--- a/packages/react-compass/src/toggle/toggle.tsx
+++ b/packages/react-compass/src/toggle/toggle.tsx
@@ -49,12 +49,16 @@ const Toggle = React.forwardRef<HTMLInputElement, ToggleProps>((props, ref) => {
   const toggleRef = useDOMRef<HTMLInputElement>(ref)
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setIsSelectedState(e.target.value === 'true')
+    const value = e.target.value === 'true'
+    setIsSelectedState(value)
+    props.onChange?.(value)
   }
 
   const onClick = () => {
     if (!isDisabled && !isReadOnly) {
-      setIsSelectedState((s) => !s)
+      const value = !isSelectedState
+      setIsSelectedState(value)
+      props.onChange?.(value)
     }
   }
 
@@ -66,10 +70,6 @@ const Toggle = React.forwardRef<HTMLInputElement, ToggleProps>((props, ref) => {
   }
 
   React.useEffect(() => {
-    props.onChange?.(isSelectedState)
-  }, [isSelectedState])
-
-  React.useEffect(() => {
     setIsSelectedState(isSelected)
   }, [isSelected])
 
@@ -77,7 +77,7 @@ const Toggle = React.forwardRef<HTMLInputElement, ToggleProps>((props, ref) => {
     <StyledToggle
       css={css}
       size={size}
-      tabIndex={0}
+      tabIndex={isDisabled ? -1 : 0}
       className={className}
       active={isSelectedState}
       disabled={!!props.isDisabled}

--- a/packages/react-compass/src/utils/useId.ts
+++ b/packages/react-compass/src/utils/useId.ts
@@ -1,0 +1,9 @@
+import {useRef} from 'react'
+
+export function useId(initId?: string) {
+  // Prevent recreate id each render time
+  const id = useRef(
+    initId ?? `cdg-element-${Math.random().toString(36).substring(2)}`,
+  )
+  return id.current
+}


### PR DESCRIPTION
# Merge request description template

## Description

**1) Root cause**

Refactor toggle using input state instead of react state

**2) Changes**

**3) Impact**

Remove react state

## Reference (optional)

## Check list

- [x] 1. Did you start and verify your changes?
- [x] 2. Did you run build to make sure that your changes can be built successfully?
- [x] 3. No !important flag, inline style in css
- [x] 4. No bolerplate codes (1)
- [x] 5. No duplicate code that exist in common functions?
- [x] 6. All of defined variables should have default value, check null and undefined?
- [x] 7. Use meaningful name for variables, no suffix 1,2,... Describes reference information for easier to understand what's inside. (2)
- [x] 9. Unsubscribed all of subscribers and even listeners when you don't need them.

```
(1)
Boilerplate codes is duplicated multiple times a bunch of the same code. This should be a common function to reuse through your code or you can use generic class / methods or design pattern to avoid the Boilerplate codes.
```

```
(2)
Follow theo coding convention
NO acronym variable name:
WRONG: el, elm
RIGHT: element
Your code can be read as a sentence
```
