### PR TITLE
Drawer - add ability to disable default accessibility behavior: autofocus and close

### DIFF
--- a/packages/react-compass/src/drawer/drawer.stories.tsx
+++ b/packages/react-compass/src/drawer/drawer.stories.tsx
@@ -9,6 +9,7 @@ import List from '../list'
 import ListImage from '../list/list-image'
 import Modal from '../modal'
 import TextField from '../textfield'
+import {styled} from '../theme'
 import Typography from '../typography'
 import {Row} from '../utils'
 import {Column} from '../utils/components'
@@ -30,12 +31,17 @@ export function H5() {
   const [openDemoTripDrawer, setOpenDemoTripDrawer] = useState(false)
   const [openConfirmModal, setOpenConfirmModal] = useState(false)
 
+  const [openNoFocusDrawer, setOpenNoFocusDrawer] = useState({
+    open: false,
+    focusContent: false,
+  })
+
   const [drawerConfig, setDrawerConfig] = useState<Partial<H5DrawerProps>>(
     h5DrawerDefaultConfig,
   )
 
   return (
-    <div style={{position: 'relative', minHeight: '100vh'}}>
+    <StyledContainer>
       <h4>H5 Drawer</h4>
       <Button type='button' onClick={() => setOpenDrawer(true)}>
         Open Drawer
@@ -46,7 +52,7 @@ export function H5() {
         Open Customizable Drawer
       </Button>
 
-      <h4 style={{marginBottom: 0}}>Demo Trip information</h4>
+      <h4>Demo Trip information</h4>
       <Typography.Body
         variant='body3'
         css={{color: '$grayShades60', marginBlock: '$2 $4'}}
@@ -77,6 +83,41 @@ export function H5() {
         onClick={() => setOpenNonModalDrawer(!openNonModalDrawer)}
       >
         Toggle Non-modal Drawer
+      </Button>
+
+      <h4>Disable autofocus on the first nested focusable element</h4>
+      <Typography.Body
+        variant='body3'
+        css={{color: '$grayShades60', marginBlock: '$2 $4'}}
+      >
+        By default, the Drawer will autofocus on the first nested focusable
+        element after opening.
+        <br />
+        To disable that, set focusContent to false
+      </Typography.Body>
+      <Button
+        css={{marginRight: '$4'}}
+        type='button'
+        onClick={() =>
+          setOpenNoFocusDrawer({
+            open: true,
+            focusContent: true,
+          })
+        }
+      >
+        Open Normal Drawer
+      </Button>
+      <Button
+        type='button'
+        variant='secondary'
+        onClick={() =>
+          setOpenNoFocusDrawer({
+            open: true,
+            focusContent: false,
+          })
+        }
+      >
+        Open autofocus disabled Drawer
       </Button>
 
       <Drawer
@@ -318,7 +359,7 @@ export function H5() {
 
       <Drawer
         open={openNonModalDrawer}
-        css={{height: '20dvh', position: 'fixed', overflow: 'hidden'}}
+        css={{height: '20dvh', position: 'fixed'}}
         expanderCSS={{
           background: '$blueShades100',
           paddingBlock: '$2 $6',
@@ -405,7 +446,63 @@ export function H5() {
           </Modal>
         </Modal.Trigger>
       </Drawer>
-    </div>
+
+      <Drawer
+        open={openNoFocusDrawer.open}
+        css={{height: '30dvh'}}
+        onClose={() => setOpenNoFocusDrawer({open: false, focusContent: false})}
+        variant='h5'
+        expandedPoint={90}
+        expandableLine={50}
+        focusContent={openNoFocusDrawer.focusContent}
+      >
+        {openNoFocusDrawer.open && (
+          <>
+            <Typography.Body variant='body3'>
+              {!openNoFocusDrawer.focusContent && 'Disable'}{' '}
+              <strong>Autofocus</strong> on the first focusable element - a
+              button at the bottom ⏬
+            </Typography.Body>
+
+            <Typography.Body
+              variant='body3'
+              css={{minHeight: '30vh', marginTop: '$10'}}
+            >
+              Lorem ipsum dolor sit amet consectetur adipisicing elit.
+              Praesentium molestias voluptatem officia at repellat, voluptates
+              corrupti quod sunt necessitatibus delectus quae enim, temporibus
+              nisi, asperiores consectetur fugiat molestiae error itaque. Animi
+              ad ut eum cupiditate tempora reiciendis, doloremque quis corporis
+              ipsam aperiam explicabo voluptatum! Possimus tempore praesentium
+              suscipit non quisquam ea assumenda, eius sit illo ratione rem
+              consequatur est dignissimos? Similique animi dolor a fugiat modi
+              nostrum maiores possimus aliquid, repudiandae commodi, suscipit
+              aliquam eaque sint repellendus illum dolorem velit. Totam
+              necessitatibus accusamus tenetur, saepe distinctio illo maiores
+              facilis sapiente! Natus, ab. Omnis deleniti optio sunt debitis
+              odio placeat exercitationem tenetur sapiente atque quod neque
+              vitae, ipsum amet quas asperiores fugit corporis quo laboriosam
+              quibusdam iure porro. Ullam, veritatis totam. Qui reprehenderit
+              quidem reiciendis dolorum nisi molestias placeat sit enim culpa
+              hic quasi, doloribus, omnis quod ea eligendi architecto? Sint
+              alias voluptatem eveniet. Ipsa dolorem, maxime dolor excepturi
+              expedita consequuntur. Earum iste voluptatum, expedita vitae
+              temporibus optio dolor eius. Eveniet quae ipsum beatae! Pariatur
+              explicabo est fuga, suscipit nulla ad a eius porro minus eveniet
+              sed eligendi impedit adipisci quaerat.
+            </Typography.Body>
+
+            <Button
+              type='button'
+              variant='secondary'
+              onClick={() => console.log('clicked')}
+            >
+              A focusable element at the bottom
+            </Button>
+          </>
+        )}
+      </Drawer>
+    </StyledContainer>
   )
 }
 
@@ -598,3 +695,15 @@ export function Default() {
     </>
   )
 }
+
+const StyledContainer = styled('div', {
+  h4: {
+    marginBlock: 0,
+  },
+  'h4:not(:first-child)': {
+    marginTop: '$14',
+  },
+  'h4 + button': {
+    marginTop: '$4',
+  },
+})

--- a/packages/react-compass/src/drawer/drawer.stories.tsx
+++ b/packages/react-compass/src/drawer/drawer.stories.tsx
@@ -13,15 +13,16 @@ import {styled} from '../theme'
 import Typography from '../typography'
 import {Row} from '../utils'
 import {Column} from '../utils/components'
-import Drawer, {DrawerProps, H5DrawerProps} from './index'
+import Drawer, {DrawerH5Props, DrawerProps} from './index'
 
 const imgSrc =
   'https://images.pexels.com/photos/777059/pexels-photo-777059.jpeg?auto=compress&cs=tinysrgb&dpr=1&w=500'
 
-const h5DrawerDefaultConfig: Partial<H5DrawerProps> = {
+const h5DrawerDefaultConfig: Partial<DrawerH5Props> = {
   disableResize: false,
   disableAddBodyAttr: false,
   autoClose: true,
+  preventClose: false,
 }
 
 export function H5() {
@@ -33,10 +34,10 @@ export function H5() {
 
   const [openNoFocusDrawer, setOpenNoFocusDrawer] = useState({
     open: false,
-    focusContent: false,
+    preventFocus: false,
   })
 
-  const [drawerConfig, setDrawerConfig] = useState<Partial<H5DrawerProps>>(
+  const [drawerConfig, setDrawerConfig] = useState<Partial<DrawerH5Props>>(
     h5DrawerDefaultConfig,
   )
 
@@ -93,7 +94,7 @@ export function H5() {
         By default, the Drawer will autofocus on the first nested focusable
         element after opening.
         <br />
-        To disable that, set focusContent to false
+        To disable that, set preventFocus to false
       </Typography.Body>
       <Button
         css={{marginRight: '$4'}}
@@ -101,7 +102,7 @@ export function H5() {
         onClick={() =>
           setOpenNoFocusDrawer({
             open: true,
-            focusContent: true,
+            preventFocus: true,
           })
         }
       >
@@ -113,7 +114,7 @@ export function H5() {
         onClick={() =>
           setOpenNoFocusDrawer({
             open: true,
-            focusContent: false,
+            preventFocus: false,
           })
         }
       >
@@ -199,6 +200,7 @@ export function H5() {
       </Drawer>
 
       <Drawer
+        {...drawerConfig}
         open={openDemoDrawer}
         css={{
           height: '40dvh',
@@ -213,7 +215,6 @@ export function H5() {
           setDrawerConfig(h5DrawerDefaultConfig)
         }}
         variant='h5'
-        {...drawerConfig}
       >
         <p>Resizable Drawer?</p>
         <Button
@@ -262,6 +263,37 @@ export function H5() {
         >
           Toggle autoclose
         </Button>
+
+        <hr />
+        <p>
+          Should prevent drawer from closing when users tap/click on the
+          backdrop or press Escape key?{' '}
+          <strong>{`${drawerConfig.preventClose}`}</strong>
+        </p>
+        <Button
+          css={{marginRight: '$4'}}
+          type='button'
+          onClick={() =>
+            setDrawerConfig((currState) => ({
+              ...currState,
+              preventClose: !currState.preventClose,
+            }))
+          }
+        >
+          Toggle prevent close
+        </Button>
+        {drawerConfig.preventClose && (
+          <Button
+            type='button'
+            variant='secondary'
+            onClick={() => {
+              setOpenDemoDrawer(false)
+              setDrawerConfig(h5DrawerDefaultConfig)
+            }}
+          >
+            Manually close drawer
+          </Button>
+        )}
       </Drawer>
 
       <Drawer
@@ -450,16 +482,16 @@ export function H5() {
       <Drawer
         open={openNoFocusDrawer.open}
         css={{height: '30dvh'}}
-        onClose={() => setOpenNoFocusDrawer({open: false, focusContent: false})}
+        onClose={() => setOpenNoFocusDrawer({open: false, preventFocus: false})}
         variant='h5'
         expandedPoint={90}
         expandableLine={50}
-        focusContent={openNoFocusDrawer.focusContent}
+        preventFocus={openNoFocusDrawer.preventFocus}
       >
         {openNoFocusDrawer.open && (
           <>
             <Typography.Body variant='body3'>
-              {!openNoFocusDrawer.focusContent && 'Disable'}{' '}
+              {!openNoFocusDrawer.preventFocus && 'Disable'}{' '}
               <strong>Autofocus</strong> on the first focusable element - a
               button at the bottom ⏬
             </Typography.Body>

--- a/packages/react-compass/src/drawer/drawer.styles.ts
+++ b/packages/react-compass/src/drawer/drawer.styles.ts
@@ -66,6 +66,12 @@ export const StyledDrawer = styled('dialog', {
   },
 
   variants: {
+    drawerMode: {
+      'non-modal': {
+        overflow: 'hidden',
+      },
+      modal: {},
+    },
     position: {
       left: {
         insetInline: '0 auto',

--- a/packages/react-compass/src/drawer/drawer.tsx
+++ b/packages/react-compass/src/drawer/drawer.tsx
@@ -38,6 +38,7 @@ const Drawer = forwardRef<HTMLDialogElement, DrawerProps>((props, ref) => {
     open = false,
     onClose,
     onMouseDown,
+    focusContent = true,
 
     variant = 'default',
     position: drawerPosition = 'right',
@@ -235,17 +236,16 @@ const Drawer = forwardRef<HTMLDialogElement, DrawerProps>((props, ref) => {
         document.body.setAttribute('inert', '')
       }
 
-      if (drawerMode === 'modal') {
-        DrawerElement.showModal()
-        return
+      if (!focusContent) {
+        DrawerElement.setAttribute('inert', '')
       }
-
-      DrawerElement.show()
+      drawerMode === 'modal' ? DrawerElement.showModal() : DrawerElement.show()
+      DrawerElement.removeAttribute('inert')
       return
     }
 
     handleCloseDrawer()
-  }, [open, DrawerElement, disableAddBodyAttr, handleCloseDrawer])
+  }, [open, DrawerElement, disableAddBodyAttr, focusContent, handleCloseDrawer])
 
   useEffect(() => {
     if (!open && drawerInitHeight) {
@@ -264,6 +264,7 @@ const Drawer = forwardRef<HTMLDialogElement, DrawerProps>((props, ref) => {
       ref={DrawerRef}
       className={`${className} ${isExpanded ? 'drawer-expanded' : ''}`}
       css={css}
+      {...{drawerMode}}
       {...{variant}}
       {...{position}}
       {...delegated}

--- a/packages/react-compass/src/drawer/drawer.tsx
+++ b/packages/react-compass/src/drawer/drawer.tsx
@@ -3,6 +3,7 @@
 import React, {
   forwardRef,
   MouseEvent,
+  ReactEventHandler,
   useCallback,
   useEffect,
   useMemo,
@@ -38,7 +39,8 @@ const Drawer = forwardRef<HTMLDialogElement, DrawerProps>((props, ref) => {
     open = false,
     onClose,
     onMouseDown,
-    focusContent = true,
+    preventFocus = true,
+    preventClose = false,
 
     variant = 'default',
     position: drawerPosition = 'right',
@@ -130,7 +132,7 @@ const Drawer = forwardRef<HTMLDialogElement, DrawerProps>((props, ref) => {
       }
 
       onMouseDown?.(e)
-      if (!(e.target instanceof HTMLDialogElement)) {
+      if (!(e.target instanceof HTMLDialogElement) || !preventClose) {
         return
       }
 
@@ -140,6 +142,15 @@ const Drawer = forwardRef<HTMLDialogElement, DrawerProps>((props, ref) => {
       }
     },
     [DrawerElement, onMouseDown, handleCloseDrawer],
+  )
+
+  const handleCancelDrawer = useCallback<ReactEventHandler<HTMLDialogElement>>(
+    (e) => {
+      if (preventClose) {
+        e.preventDefault()
+      }
+    },
+    [preventClose],
   )
 
   const handleExpanderDragStart = useCallback<
@@ -236,7 +247,7 @@ const Drawer = forwardRef<HTMLDialogElement, DrawerProps>((props, ref) => {
         document.body.setAttribute('inert', '')
       }
 
-      if (!focusContent) {
+      if (!preventFocus) {
         DrawerElement.setAttribute('inert', '')
       }
       drawerMode === 'modal' ? DrawerElement.showModal() : DrawerElement.show()
@@ -245,7 +256,7 @@ const Drawer = forwardRef<HTMLDialogElement, DrawerProps>((props, ref) => {
     }
 
     handleCloseDrawer()
-  }, [open, DrawerElement, disableAddBodyAttr, focusContent, handleCloseDrawer])
+  }, [open, DrawerElement, disableAddBodyAttr, preventFocus, handleCloseDrawer])
 
   useEffect(() => {
     if (!open && drawerInitHeight) {
@@ -277,6 +288,7 @@ const Drawer = forwardRef<HTMLDialogElement, DrawerProps>((props, ref) => {
       }}
       onMouseDown={handleMouseDown}
       onClose={onClose}
+      onCancel={handleCancelDrawer}
     >
       {variant === 'h5' && !disableResize && (
         <DrawerExpander

--- a/packages/react-compass/src/drawer/index.ts
+++ b/packages/react-compass/src/drawer/index.ts
@@ -4,7 +4,7 @@ import DrawerHeader from './drawer-header'
 
 export type {DrawerFooterProps} from './drawer-footer'
 export type {DrawerHeaderProps} from './drawer-header'
-export type {DrawerProps, H5DrawerProps} from './types'
+export type {DrawerDefaultProps, DrawerH5Props, DrawerProps} from './types'
 
 Drawer.Header = DrawerHeader
 Drawer.Footer = DrawerFooter

--- a/packages/react-compass/src/drawer/types.ts
+++ b/packages/react-compass/src/drawer/types.ts
@@ -32,12 +32,17 @@ interface DrawerSharedProps {
    */
   drawerMode?: 'non-modal' | 'modal'
   /**
-   * If `false`, disable a default behavior of `<dialog>` element:
+   * If `true`, disable a default behavior of `<dialog>` element:
    *
    * Browser won't autofocus on the first nested focusable element anymore.
-   * @default true
+   * @default false
    */
-  focusContent?: boolean
+  preventFocus?: boolean
+  /**
+   * If `true`, the drawer won't close when users press `Escape` key or click/tap on the backdrop.
+   * @default false
+   */
+  preventClose?: boolean
 }
 
 interface DefaultDrawerProps {
@@ -53,7 +58,7 @@ interface DefaultDrawerProps {
   autoClose?: never
 }
 
-export interface H5DrawerProps {
+interface H5DrawerProps {
   variant: 'h5'
   position?: never
   expanderCSS?: StyledComponentProps['css']
@@ -103,6 +108,9 @@ export interface H5DrawerProps {
    */
   autoClose?: boolean
 }
+
+export type DrawerH5Props = DrawerSharedProps & H5DrawerProps
+export type DrawerDefaultProps = DrawerSharedProps & DefaultDrawerProps
 
 type Props = DrawerSharedProps &
   (DefaultDrawerProps | H5DrawerProps) &

--- a/packages/react-compass/src/drawer/types.ts
+++ b/packages/react-compass/src/drawer/types.ts
@@ -31,6 +31,13 @@ interface DrawerSharedProps {
    *
    */
   drawerMode?: 'non-modal' | 'modal'
+  /**
+   * If `false`, disable a default behavior of `<dialog>` element:
+   *
+   * Browser won't autofocus on the first nested focusable element anymore.
+   * @default true
+   */
+  focusContent?: boolean
 }
 
 interface DefaultDrawerProps {
@@ -103,4 +110,7 @@ type Props = DrawerSharedProps &
 
 export type DrawerProps = Props &
   Omit<DrawerVariantProps, 'position'> &
-  Omit<DialogHTMLAttributes<HTMLDialogElement>, keyof Props>
+  Omit<
+    DialogHTMLAttributes<HTMLDialogElement>,
+    keyof Props | 'tabIndex' | 'autoFocus'
+  >

--- a/packages/react-compass/src/index.ts
+++ b/packages/react-compass/src/index.ts
@@ -105,7 +105,13 @@ export type {
 export {default as Divider} from './divider'
 export type {DividerProps} from './divider'
 export {default as Drawer} from './drawer'
-export type {DrawerFooterProps, DrawerHeaderProps, DrawerProps} from './drawer'
+export type {
+  DrawerDefaultProps,
+  DrawerFooterProps,
+  DrawerH5Props,
+  DrawerHeaderProps,
+  DrawerProps,
+} from './drawer'
 export {default as Dropdown} from './dropdown'
 export type {
   DropdownComboBoxProps,


### PR DESCRIPTION
## Description

**1) Root cause**

By default, the Drawer will autofocus on the first nested focusable element after opening and will close itself when users press Escape key or click/tap on the backdrop.

**2) Changes**

Allow users to disable these default behaviors.

**3) Impact**

Drawer component

## Check list

- [x] 1. Did you start and verify your changes?
- [x] 2. Did you run build to make sure that your changes can be built successfully?
- [x] 3. No !important flag, inline style in css
- [x] 4. No boilerplate codes (1)
- [x] 5. No duplicate code that exist in common functions?
- [x] 6. All of defined variables should have default value, check null and undefined?
- [x] 7. Use meaningful name for variables, no suffix 1,2,... Describes reference information for easier to understand what's inside. (2)
- [x] 9. Unsubscribed all of subscribers and even listeners when you don't need them.

```
(1)
Boilerplate codes is duplicated multiple times a bunch of the same code. This should be a common function to reuse through your code or you can use generic class / methods or design pattern to avoid the Boilerplate codes.
```

```
(2)
Follow theo coding convention
NO acronym variable name:
WRONG: el, elm
RIGHT: element
Your code can be read as a sentence
```
