### PR TITLE
[NGPDCP-2923] Implement H5 variant for Textarea component

### DIFF
--- a/apps/docs-v2/data/components/textarea/TextareaH5.tsx
+++ b/apps/docs-v2/data/components/textarea/TextareaH5.tsx
@@ -1,0 +1,22 @@
+import { Textarea } from '@comfortdelgro/react-compass'
+
+function TextareaH5() {
+  return (
+    <Textarea
+      variant='h5'
+      resizable={false}
+      placeholder='Type your feedback here'
+      wordCount
+      maxLength={200}
+      css={{
+        textarea: {
+          width: '343px',
+          height: '129px',
+        },
+      }}
+      label='Details'
+    />
+  )
+}
+
+export default TextareaH5

--- a/apps/docs-v2/data/components/textarea/TextareaH5.tsx.preview
+++ b/apps/docs-v2/data/components/textarea/TextareaH5.tsx.preview
@@ -1,0 +1,14 @@
+<Textarea
+  variant='h5'
+  resizable={false}
+  placeholder='Type your feedback here'
+  wordCount
+  maxLength={200}
+  css={{
+  textarea: {
+    width: '343px',
+    height: '129px',
+    },
+  }}
+  label='Details'
+/>

--- a/apps/docs-v2/data/components/textarea/textarea.md
+++ b/apps/docs-v2/data/components/textarea/textarea.md
@@ -28,6 +28,9 @@ import Textarea from '@comfortdelgro/react-compass/textarea'
 ### Custom styling
 
 {{"demo": "TextareaCustom.tsx"}}
+### H5 project styling
+
+{{"demo": "TextareaH5.tsx"}}
 
 ## Props
 
@@ -42,3 +45,5 @@ import Textarea from '@comfortdelgro/react-compass/textarea'
 | `wordCount`   | `false`\| `true`   | `false` | `Show word count of the input when true` |
 | `maxLength`   | `number`           | —       | `Limit length of the input`              |
 | `onChange`    | `function`         | —       |                                          |
+| `variant`     | `string`           | —       | `Specific style for particular projects` |
+| `resizable`   | `boolean`          | `true`  | `Whether the textarea is resizable`      |

--- a/packages/react-compass/src/textarea/textarea.stories.tsx
+++ b/packages/react-compass/src/textarea/textarea.stories.tsx
@@ -10,6 +10,21 @@ export const Variants: React.FC = () => {
 
   return (
     <Column>
+      <h3> H5</h3>
+      <Textarea
+        variant='h5'
+        resizable={false}
+        placeholder='Type your feedback here'
+        css={{
+          textarea: {
+            width: '343px',
+            height: '129px',
+          },
+        }}
+        label='Details'
+        wordCount
+        maxLength={200}
+      />
       <h3> Simple textarea</h3>
       <Textarea placeholder='Enter your message' />
       <br />

--- a/packages/react-compass/src/textarea/textarea.styles.ts
+++ b/packages/react-compass/src/textarea/textarea.styles.ts
@@ -60,6 +60,15 @@ export const StyledTextarea = styled('textarea', {
         },
       },
     },
+
+    resizable: {
+      false: {
+        resize: 'none',
+      },
+      true: {
+        resize: 'both',
+      },
+    },
   },
 
   defaultVariants: {
@@ -100,7 +109,41 @@ export const StyledTextareaWrapper = styled('div', {
         },
       },
     },
+    variant: {
+      h5: {
+        gap: '4px',
+        [`${StyledTextAreaLabel}`]: {
+          color: '$grayShades80',
+          fontSize: '$label2',
+          fontWeight: 500,
+          marginBottom: 0,
+        },
+        [`${StyledTextarea}`]: {
+          padding: '$3 $4',
+          borderRadius: '$lg',
+          border: '1px solid $grayShades20',
+          backgroundColor: '$background',
+          fontSize: '$label2',
+          '&::placeholder': {
+            fontSize: '$label2',
+            fontWeight: 400,
+            lineHeight: '$tight',
+            color: '$grayShades40',
+          },
+        },
+        [`${StyledTextAreaHelperText}`]: {
+          fontSize: '$label2',
+          fontWeight: 500,
+          lineHeight: 'normal',
+          color: '$grayShades40',
+          marginTop: 0,
+        },
+      },
+    },
   },
 })
 
 export type TextareaVariantProps = VariantProps<typeof StyledTextarea>
+export type TextareaVariantWrapperProps = VariantProps<
+  typeof StyledTextareaWrapper
+>

--- a/packages/react-compass/src/textarea/textarea.tsx
+++ b/packages/react-compass/src/textarea/textarea.tsx
@@ -8,6 +8,7 @@ import {
   StyledTextAreaLabel,
   StyledTextareaWrapper,
   TextareaVariantProps,
+  TextareaVariantWrapperProps,
 } from './textarea.styles'
 
 interface Props extends StyledComponentProps {
@@ -70,6 +71,8 @@ interface Props extends StyledComponentProps {
   'aria-describedby'?: string
   'aria-details'?: string
   'aria-errormessage'?: string
+  variant?: TextareaVariantWrapperProps['variant']
+  resizable?: boolean
 }
 
 export type TextareaProps = Props &
@@ -117,6 +120,8 @@ const Textarea = React.forwardRef<HTMLDivElement, TextareaProps>(
       onBlur = () => null,
       onKeyDown = () => null,
       onKeyUp = () => null,
+      resizable = true,
+      variant,
       ...delegated
     } = props
     const isDarkTheme = useIsDarkTheme()
@@ -141,6 +146,7 @@ const Textarea = React.forwardRef<HTMLDivElement, TextareaProps>(
         ref={wrapperRef}
         {...delegated}
         isDarkTheme={isDarkTheme}
+        {...(variant ? {variant} : {})}
       >
         {label && (
           <StyledTextAreaLabel htmlFor={textareaId}>
@@ -180,6 +186,7 @@ const Textarea = React.forwardRef<HTMLDivElement, TextareaProps>(
           onCompositionEnd={onCompositionEnd}
           onCompositionStart={onCompositionStart}
           onCompositionUpdate={onCompositionUpdate}
+          resizable={resizable}
         />
         {wordCount && (
           <StyledTextAreaHelperText className='word-count'>


### PR DESCRIPTION
# Merge request description template

## Description

**1) Root cause**

<!-- Describe reason why -->

**2) Changes**

Add new variant props `h5` props to TextArea component and props `resizable` to enable/disable textarea resizing

Add ladle example:

![image](https://github.com/comfortdelgro/compass-design/assets/7071853/9899444d-e58a-4ecd-bebd-3a2c18944766)

Add example in docs v2:

![image](https://github.com/comfortdelgro/compass-design/assets/7071853/fa845652-0bff-4539-a9d5-7c02d9714dca)

![image](https://github.com/comfortdelgro/compass-design/assets/7071853/a43e8b7b-682e-4e66-946e-26fc49648617)


**3) Impact**

<!-- Impact to function, screen or module -->

## Reference (optional)

<!-- Link to JIRA -->

## Check list

- [x] 1. Did you start and verify your changes?
- [x] 2. Did you run build to make sure that your changes can be built successfully?
- [x] 3. No !important flag, inline style in css
- [x] 4. No boilerplate codes (1)
- [x] 5. No duplicate code that exist in common functions?
- [x] 6. All of defined variables should have default value, check null and undefined?
- [x] 7. Use meaningful name for variables, no suffix 1,2,... Describes reference information for easier to understand what's inside. (2)
- [x] 9. Unsubscribed all of subscribers and even listeners when you don't need them.

```
(1)
Boilerplate codes is duplicated multiple times a bunch of the same code. This should be a common function to reuse through your code or you can use generic class / methods or design pattern to avoid the Boilerplate codes.
```

```
(2)
Follow theo coding convention
NO acronym variable name:
WRONG: el, elm
RIGHT: element
Your code can be read as a sentence
```
