### PR TITLE
[CDS-703] Fix for icon size on Safari

### DIFF
--- a/packages/react-compass/src/badge/badge.styles.ts
+++ b/packages/react-compass/src/badge/badge.styles.ts
@@ -21,11 +21,10 @@ export const StyledBadge = styled('div', {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'start',
-  },
-
-  'svg': {
-    height: '$3',
-    width: '100%',
+    'svg': {
+      height: '$3',
+      width: '100%',
+    },
   },
 
   '& > .label': {

--- a/packages/react-compass/src/badge/badge.styles.ts
+++ b/packages/react-compass/src/badge/badge.styles.ts
@@ -23,7 +23,7 @@ export const StyledBadge = styled('div', {
     justifyContent: 'start',
   },
 
-  '& > svg': {
+  'svg': {
     height: '$3',
     width: '100%',
   },


### PR DESCRIPTION
# Merge request description template

## Description

**1) Root cause**

`& > svg` selector does not work on Safari


**2) Changes**

Use only `svg` and move it into `.icon` selector

<img width="446" alt="Screenshot 2023-09-08 at 21 28 20" src="https://github.com/comfortdelgro/compass-design/assets/119040724/c78b8d5b-e761-49bb-8b6d-2c866d785285">


**3) Impact**

<!-- Impact to function, screen or module -->

## Reference (optional)

https://comfortdelgrotaxi.atlassian.net/browse/CDS-703

## Check list

- [x] 1. Did you start and verify your changes?
- [x] 2. Did you run build to make sure that your changes can be built successfully?
- [x] 3. No !important flag, inline style in css
- [x] 4. No boilerplate codes (1)
- [x] 5. No duplicate code that exist in common functions?
- [x] 6. All of defined variables should have default value, check null and undefined?
- [x] 7. Use meaningful name for variables, no suffix 1,2,... Describes reference information for easier to understand what's inside. (2)
- [x] 9. Unsubscribed all of subscribers and even listeners when you don't need them.

```
(1)
Boilerplate codes is duplicated multiple times a bunch of the same code. This should be a common function to reuse through your code or you can use generic class / methods or design pattern to avoid the Boilerplate codes.
```

```
(2)
Follow theo coding convention
NO acronym variable name:
WRONG: el, elm
RIGHT: element
Your code can be read as a sentence
```
