### PR TITLE
[NGPDCP-2901] OTP Input - add mobile UI for H5

### DIFF
--- a/apps/docs/data/components/otp-input/OTPInput.tsx
+++ b/apps/docs/data/components/otp-input/OTPInput.tsx
@@ -1,50 +1,44 @@
-import {Flexbox, OTPInput, Typography} from '@comfortdelgro/react-compass'
+import {Column, OTPInput, Typography} from '@comfortdelgro/react-compass'
 
 function Default() {
   return (
-    <Flexbox
-      css={{
-        justifyContent: 'center',
-        alignItems: 'center',
-        flexDirection: 'column',
-      }}
-    >
-      <Typography.Label css={{justifyContent: 'center', display: 'flex'}}>
-        Number OTP
-      </Typography.Label>
-      <OTPInput
-        length={4}
-        isNumberInput
-        autoFocus
-        onChangeOTP={(otp) => console.log('Number OTP: ', otp)}
-      />{' '}
-      <Typography.Label css={{justifyContent: 'center', display: 'flex'}}>
-        6 Numbers
-      </Typography.Label>
-      <OTPInput
-        length={6}
-        isNumberInput
-        autoFocus
-        onChangeOTP={(otp) => console.log('Number OTP: ', otp)}
-      />
+    <Column>
       <Typography.Label css={{justifyContent: 'center', display: 'flex'}}>
         String OTP
       </Typography.Label>
       <OTPInput
         autoFocus
-        length={4}
         onChangeOTP={(otp) => console.log('String OTP: ', otp)}
       />
+
+      <Typography.Label css={{justifyContent: 'center', display: 'flex'}}>
+        Number OTP
+      </Typography.Label>
+      <OTPInput
+        isNumberInput
+        autoFocus
+        onChangeOTP={(otp) => console.log('Number OTP: ', otp)}
+      />
+
+      <Typography.Label css={{justifyContent: 'center', display: 'flex'}}>
+        4 Numbers
+      </Typography.Label>
+      <OTPInput
+        length={4}
+        isNumberInput
+        autoFocus
+        onChangeOTP={(otp) => console.log('Number OTP: ', otp)}
+      />
+
       <Typography.Label css={{justifyContent: 'center', display: 'flex'}}>
         Disabled
       </Typography.Label>
       <OTPInput
         autoFocus
         disabled
-        length={4}
         onChangeOTP={(otp) => console.log('String OTP: ', otp)}
       />
-    </Flexbox>
+    </Column>
   )
 }
 

--- a/apps/docs/data/components/otp-input/OTPInput.tsx.preview
+++ b/apps/docs/data/components/otp-input/OTPInput.tsx.preview
@@ -1,35 +1,11 @@
-<Typography.Label css={{justifyContent: 'center', display: 'flex'}}>
-    Number OTP
-</Typography.Label>
-    <OTPInput
-    length={4}
-    isNumberInput
-    autoFocus
-    onChangeOTP={(otp) => console.log('Number OTP: ', otp)}
-    />{' '}
-<Typography.Label css={{justifyContent: 'center', display: 'flex'}}>
-    6 Numbers
-</Typography.Label>
-    <OTPInput
-    length={6}
-    isNumberInput
-    autoFocus
-    onChangeOTP={(otp) => console.log('Number OTP: ', otp)}
-    />  
-<Typography.Label css={{justifyContent: 'center', display: 'flex'}}>
-    String OTP
-</Typography.Label>
-    <OTPInput
-    autoFocus
-    length={4}
-    onChangeOTP={(otp) => console.log('String OTP: ', otp)}
-    />
-<Typography.Label css={{justifyContent: 'center', display: 'flex'}}>
-    Disabled
-</Typography.Label>
-    <OTPInput
-    autoFocus
-    disabled
-    length={4}
-    onChangeOTP={(otp) => console.log('String OTP: ', otp)}
-    />
+// Default: String OTP
+<OTPInput onChangeOTP={(otp) => console.log('String OTP: ', otp)} />
+
+// Number OTP
+<OTPInput isNumberInput />
+    
+// 4 Inputs
+<OTPInput length={4} />
+
+// Disabled state
+<OTPInput disabled />

--- a/apps/docs/data/components/otp-input/OTPInputMobile.tsx
+++ b/apps/docs/data/components/otp-input/OTPInputMobile.tsx
@@ -1,0 +1,13 @@
+import OTPInput from '@comfortdelgro/react-compass/otp-input'
+
+export default function OTPInputMobileView() {
+  return (
+    <OTPInput
+      autoFocus
+      length={4}
+      isNumberInput
+      isMobile
+      onChangeOTP={(otp) => console.log('OTP: ', otp)}
+    />
+  )
+}

--- a/apps/docs/data/components/otp-input/OTPInputMobile.tsx.preview
+++ b/apps/docs/data/components/otp-input/OTPInputMobile.tsx.preview
@@ -1,0 +1,1 @@
+<OTPInput isMobile />

--- a/apps/docs/data/components/otp-input/otp-input.md
+++ b/apps/docs/data/components/otp-input/otp-input.md
@@ -23,12 +23,19 @@ import OTPInput from '@comfortdelgro/react-compass/otpinput'
 
 {{"demo": "OTPInput.tsx"}}
 
+## Mobile view example
+
+{{"demo": "OTPInputMobile.tsx"}}
+
 ## Props
 
-| Name          | Type     | Default | Description                          |
-| :------------ | :------- | :------ | :----------------------------------- |
-| length        | `number` | —       | The length of the OTP input          |
-| isNumberInput | `bool`   | `false` | Whether the input should be numbers  |
-| autoFocus     | `bool`   | `false` | Whether to autofocus the first input |
-| onChangeOTP   | `func`   | —       | Callback when the OTP value changes  |
-| disabled      | `bool`   | `false` | Whether the input should be disabled |
+| Name          | Type                    | Default | Description                          |
+| :------------ | :---------------------- | :------ | :----------------------------------- |
+| length        | `number`                | 6       | The length of the OTP input          |
+| isNumberInput | `boolean`               | `false` | Whether the input should be numbers  |
+| autoFocus     | `boolean`               | `false` | Whether to autofocus the first input |
+| onChangeOTP\* | `(otp: string) => void` | —       | Callback when the OTP value changes  |
+| disabled      | `boolean`               | `false` | Whether the input should be disabled |
+| isMobile      | `boolean`               | `false` | Mobile UI                            |
+
+\*: Required.

--- a/apps/docs/data/components/otp-input/otp-input.md
+++ b/apps/docs/data/components/otp-input/otp-input.md
@@ -16,14 +16,14 @@ import {OTPInput} from '@comfortdelgro/react-compass'
 or
 
 ```jsx
-import OTPInput from '@comfortdelgro/react-compass/otpinput'
+import OTPInput from '@comfortdelgro/react-compass/otp-input'
 ```
 
-## Example
+## Examples
 
 {{"demo": "OTPInput.tsx"}}
 
-## Mobile view example
+## Mobile view
 
 {{"demo": "OTPInputMobile.tsx"}}
 
@@ -36,6 +36,6 @@ import OTPInput from '@comfortdelgro/react-compass/otpinput'
 | autoFocus     | `boolean`               | `false` | Whether to autofocus the first input |
 | onChangeOTP\* | `(otp: string) => void` | —       | Callback when the OTP value changes  |
 | disabled      | `boolean`               | `false` | Whether the input should be disabled |
-| isMobile      | `boolean`               | `false` | Mobile UI                            |
+| isMobile      | `boolean`               | `false` | Toggle Mobile UI                     |
 
 \*: Required.

--- a/packages/react-compass/src/otp-input/OTPInput.tsx
+++ b/packages/react-compass/src/otp-input/OTPInput.tsx
@@ -8,11 +8,13 @@ import {
 import SingleInput from './SingleInput'
 
 export interface Props extends StyledComponentProps {
-  length: number
-  onChangeOTP: (otp: string) => unknown
+  /** @default 6 */
+  length?: number
+  onChangeOTP: (otp: string) => void
   autoFocus?: boolean
   isNumberInput?: boolean
   disabled?: boolean
+  isMobile?: boolean
 }
 export type OTPInputProps = Props &
   OtpInputContainerVariantProps &
@@ -22,10 +24,11 @@ const OTPInputComponent = React.forwardRef<HTMLDivElement, OTPInputProps>(
   (props, ref) => {
     const {
       css = {},
-      length,
+      length = 6,
       isNumberInput,
       autoFocus,
       disabled,
+      isMobile = false,
       onChangeOTP,
       ...delegated
     } = props
@@ -118,9 +121,9 @@ const OTPInputComponent = React.forwardRef<HTMLDivElement, OTPInputProps>(
             e.preventDefault()
             if (otpValues[activeInput]) {
               changeCodeAtFocus('')
-            } else {
-              focusPrevInput()
             }
+
+            focusPrevInput()
             break
           }
           case 'ArrowLeft': {
@@ -178,23 +181,30 @@ const OTPInputComponent = React.forwardRef<HTMLDivElement, OTPInputProps>(
     )
 
     return (
-      <StyledOtpInputContainer css={css} ref={inputRef} {...delegated}>
-        {Array(length)
-          .fill('')
-          .map((_, index) => (
-            <SingleInput
-              key={`SingleInput-${index}`}
-              focus={activeInput === index}
-              autoFocus={autoFocus}
-              value={otpValues && otpValues[index]}
-              onFocus={handleOnFocus(index)}
-              onChange={handleOnChange}
-              onKeyDown={handleOnKeyDown}
-              onBlur={onBlur}
-              onPaste={handleOnPaste}
-              disabled={disabled}
-            />
-          ))}
+      <StyledOtpInputContainer
+        css={css}
+        ref={inputRef}
+        isMobile={isMobile}
+        {...delegated}
+      >
+        {Array.from(Array(length).keys()).map((index) => (
+          <SingleInput
+            key={`SingleInput-${index}`}
+            focus={activeInput === index}
+            autoFocus={autoFocus}
+            value={otpValues && otpValues[index]}
+            onFocus={handleOnFocus(index)}
+            onChange={handleOnChange}
+            onKeyDown={handleOnKeyDown}
+            onBlur={onBlur}
+            onPaste={handleOnPaste}
+            {...(isNumberInput
+              ? {type: 'number', pattern: 'd{1}', inputMode: 'numeric'}
+              : undefined)}
+            autoComplete='one-time-code'
+            disabled={disabled}
+          />
+        ))}
       </StyledOtpInputContainer>
     )
   },

--- a/packages/react-compass/src/otp-input/otpInput.stories.tsx
+++ b/packages/react-compass/src/otp-input/otpInput.stories.tsx
@@ -17,7 +17,6 @@ export const Variants: React.FC = () => {
 
       <h2>6 Numbers</h2>
       <OTPInput
-        length={6}
         isNumberInput
         autoFocus
         onChangeOTP={(otp) => console.log('Number OTP: ', otp)}
@@ -32,10 +31,19 @@ export const Variants: React.FC = () => {
 
       <h2>Disabled</h2>
       <OTPInput
-        autoFocus
         disabled
         length={4}
         onChangeOTP={(otp) => console.log('String OTP: ', otp)}
+      />
+
+      <h2>Mobile view</h2>
+      <OTPInput
+        css={{marginBottom: '$8'}}
+        length={4}
+        onChangeOTP={(otp) => console.log('String OTP: ', otp)}
+        autoFocus
+        isNumberInput
+        isMobile
       />
     </Column>
   )
@@ -47,7 +55,7 @@ export default {
       <div>
         <style
           dangerouslySetInnerHTML={{
-            __html: `.ladle-main { background: #eee; }`,
+            __html: `.ladle-main { background: #F7F8F9; }`,
           }}
         ></style>
         <Component />

--- a/packages/react-compass/src/otp-input/otpInput.styles.ts
+++ b/packages/react-compass/src/otp-input/otpInput.styles.ts
@@ -7,13 +7,23 @@ export const StyledOtpSingleInput = styled('input', {
   boxSizing: 'border-box',
   padding: '0px',
   lineHeight: '1em',
-  width: '3rem !important',
+  width: '3rem',
   height: '3rem',
   margin: '0',
   fontSize: '2rem',
   textAlign: 'center',
   borderRadius: '10px',
   border: '1px solid rgba(0, 0, 0, 0.2)',
+
+  '&[type=number]': {
+    '-moz-appearance': 'textfield',
+
+    '&::-webkit-outer-spin-button, &::-webkit-inner-spin-button': {
+      '-webkit-appearance': 'none',
+      margin: 0,
+    },
+  },
+
   '&:disabled': {
     cursor: 'not-allowed',
   },
@@ -32,10 +42,29 @@ export const StyledOtpInputContainer = styled('div', {
   '@media screen and (max-width: 640px)': {
     gap: '1rem',
     input: {
-      width: '2.5rem !important',
+      width: '2.5rem',
       height: '2.5rem',
       fontSize: '1.8rem',
       borderRadius: '6px',
+    },
+  },
+
+  variants: {
+    isMobile: {
+      true: {
+        margin: 0,
+
+        [`${StyledOtpSingleInput}`]: {
+          height: '$16',
+          width: '$12',
+
+          fontSize: '$label1',
+          lineHeight: '$tight',
+
+          borderRadius: '$lg',
+          borderColor: '$grayShades20',
+        },
+      },
     },
   },
 })


### PR DESCRIPTION
## Description

**1) Changes**

- `length` now is an optional prop (default: 6).
- The return type of `onChangeOTP` should be `void` instead of `unknown`.
- Add `isMobile` - mobile view (for H5 project)

![image](https://github.com/comfortdelgro/compass-design/assets/142210010/3c1ed102-48bc-457c-865c-6a057ea61461)

**2) Impact**

OTP Input component

## Reference (optional)

[NGPDCP-2901](https://comfortdelgrotaxi.atlassian.net/browse/NGPDCP-2901)

## Check list

- [x] 1. Did you start and verify your changes?
- [x] 2. Did you run build to make sure that your changes can be built successfully?
- [x] 3. No !important flag, inline style in css
- [x] 4. No boilerplate codes (1)
- [x] 5. No duplicate code that exist in common functions?
- [x] 6. All of defined variables should have default value, check null and undefined?
- [x] 7. Use meaningful name for variables, no suffix 1,2,... Describes reference information for easier to understand what's inside. (2)
- [x] 9. Unsubscribed all of subscribers and even listeners when you don't need them.

```
(1)
Boilerplate codes is duplicated multiple times a bunch of the same code. This should be a common function to reuse through your code or you can use generic class / methods or design pattern to avoid the Boilerplate codes.
```

```
(2)
Follow theo coding convention
NO acronym variable name:
WRONG: el, elm
RIGHT: element
Your code can be read as a sentence
```


[NGPDCP-2901]: https://comfortdelgrotaxi.atlassian.net/browse/NGPDCP-2901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ