### PR TITLE
[CDS-874] Support multiple items on the same page

### DIFF
--- a/apps/docs/data/components/carousel/MultipleSlides.tsx
+++ b/apps/docs/data/components/carousel/MultipleSlides.tsx
@@ -1,40 +1,43 @@
 import CarouselSlider from '@comfortdelgro/react-compass/carousel'
-import {useState} from 'react'
+import {useEffect, useState} from 'react'
+import style from './sample.module.css'
 
 const Sliders = () => {
   const [activeIndex, setActiveIndex] = useState(0)
+  const [count, setCount] = useState(3)
 
   const handleSwitchSlide = (index: number) => {
     setActiveIndex(index)
   }
 
+  useEffect(() => {
+    const handleResize = () => {
+      const itemPerpage = window.innerWidth >= 768 ? 3 : 1
+      setCount(itemPerpage)
+    }
+    window.addEventListener('resize', handleResize)
+
+    return () => {
+      window.removeEventListener('resize', handleResize)
+    }
+  }, [])
+
   return (
     <CarouselSlider
       onSwitchSlide={handleSwitchSlide}
       effect={'slide'}
-      className='floating-slide'
-      itemPerPage={3}
-      style={{height: '512px'}}
+      className={style.myMultipleSlidesSlider}
+      itemPerPage={count}
     >
       {Array.from({length: 9}).map((item, index) => (
         <CarouselSlider.Slide
           key={index}
-          className={`slider-side${activeIndex === index ? ' active' : ''}`}
+          className={`slider-side responsive-slide${
+            activeIndex === index ? ' active' : ''
+          }`}
           active={false}
-          css={{
-            width: '33.33% !important',
-            padding: '0 20px',
-          }}
         >
-          <div
-            style={{
-              backgroundColor: '#ccc',
-              border: '1px solid #aaa',
-              height: '100%',
-            }}
-          >
-            Carousel slide {index}
-          </div>
+          <div className={style.sampleSlideInner}>Carousel slide {index}</div>
         </CarouselSlider.Slide>
       ))}
     </CarouselSlider>

--- a/apps/docs/data/components/carousel/MultipleSlides.tsx
+++ b/apps/docs/data/components/carousel/MultipleSlides.tsx
@@ -1,0 +1,44 @@
+import CarouselSlider from '@comfortdelgro/react-compass/carousel'
+import {useState} from 'react'
+
+const Sliders = () => {
+  const [activeIndex, setActiveIndex] = useState(0)
+
+  const handleSwitchSlide = (index: number) => {
+    setActiveIndex(index)
+  }
+
+  return (
+    <CarouselSlider
+      onSwitchSlide={handleSwitchSlide}
+      effect={'slide'}
+      className='floating-slide'
+      itemPerPage={3}
+      style={{height: '512px'}}
+    >
+      {Array.from({length: 9}).map((item, index) => (
+        <CarouselSlider.Slide
+          key={index}
+          className={`slider-side${activeIndex === index ? ' active' : ''}`}
+          active={false}
+          css={{
+            width: '33.33% !important',
+            padding: '0 20px',
+          }}
+        >
+          <div
+            style={{
+              backgroundColor: '#ccc',
+              border: '1px solid #aaa',
+              height: '100%',
+            }}
+          >
+            Carousel slide {index}
+          </div>
+        </CarouselSlider.Slide>
+      ))}
+    </CarouselSlider>
+  )
+}
+
+export default Sliders

--- a/apps/docs/data/components/carousel/MultipleSlides.tsx.preview
+++ b/apps/docs/data/components/carousel/MultipleSlides.tsx.preview
@@ -1,29 +1,71 @@
-<CarouselSlider
-    onSwitchSlide={handleSwitchSlide}
-    effect={'slide'}
-    className='floating-slide'
-    itemPerPage={3}
-    style={{height: '512px'}}
->
-    {Array.from({length: 9}).map((item, index) => (
-    <CarouselSlider.Slide
-        key={index}
-        className={`slider-side${activeIndex === index ? ' active' : ''}`}
-        active={false}
-        css={{
-        width: '33.33% !important', // Important flag is just for sample, you just need to give it more complex on css selector
-        padding: '0 20px',
-        }}
+import CarouselSlider from '@comfortdelgro/react-compass/carousel'
+import {useEffect, useState} from 'react'
+import style from './sample.module.css'
+
+const Sliders = () => {
+  const [activeIndex, setActiveIndex] = useState(0)
+  const [count, setCount] = useState(3)
+
+  const handleSwitchSlide = (index: number) => {
+    setActiveIndex(index)
+  }
+
+  useEffect(() => {
+    const handleResize = () => {
+      const itemPerpage = window.innerWidth >= 768 ? 3 : 1
+      setCount(itemPerpage)
+    }
+    window.addEventListener('resize', handleResize)
+
+    return () => {
+      window.removeEventListener('resize', handleResize)
+    }
+  }, [])
+
+  return (
+    <CarouselSlider
+      onSwitchSlide={handleSwitchSlide}
+      effect={'slide'}
+      className={style.myMultipleSlidesSlider}
+      itemPerPage={count}
     >
-        <div
-        style={{
-            backgroundColor: '#ccc',
-            border: '1px solid #aaa',
-            height: '100%',
-        }}
+      {Array.from({length: 9}).map((item, index) => (
+        <CarouselSlider.Slide
+          key={index}
+          className={`slider-side responsive-slide${
+            activeIndex === index ? ' active' : ''
+          }`}
+          active={false}
         >
-        Carousel slide {index}
-        </div>
-    </CarouselSlider.Slide>
-    ))}
-</CarouselSlider>
+          <div className={style.sampleSlideInner}>Carousel slide {index}</div>
+        </CarouselSlider.Slide>
+      ))}
+    </CarouselSlider>
+  )
+}
+
+export default Sliders
+
+/** CSS **/
+.myMultipleSlidesSlider:global(.content-slider .slider-side.responsive-slide) {
+  display: flex;
+  height: 100%;
+  width: 33.33%;
+}
+
+.sampleSlideInner {
+  background-color: #ccc;
+  border: 1px solid #aaa;
+  width: 100%;
+  height: 250px;
+}
+
+@media screen and (max-width: 768px) {
+  .myMultipleSlidesSlider:global(
+      .content-slider .slider-side.responsive-slide
+    ) {
+    display: flex;
+    height: 100%;
+    width: 100%;
+  }
+}

--- a/apps/docs/data/components/carousel/MultipleSlides.tsx.preview
+++ b/apps/docs/data/components/carousel/MultipleSlides.tsx.preview
@@ -1,0 +1,29 @@
+<CarouselSlider
+    onSwitchSlide={handleSwitchSlide}
+    effect={'slide'}
+    className='floating-slide'
+    itemPerPage={3}
+    style={{height: '512px'}}
+>
+    {Array.from({length: 9}).map((item, index) => (
+    <CarouselSlider.Slide
+        key={index}
+        className={`slider-side${activeIndex === index ? ' active' : ''}`}
+        active={false}
+        css={{
+        width: '33.33% !important', // Important flag is just for sample, you just need to give it more complex on css selector
+        padding: '0 20px',
+        }}
+    >
+        <div
+        style={{
+            backgroundColor: '#ccc',
+            border: '1px solid #aaa',
+            height: '100%',
+        }}
+        >
+        Carousel slide {index}
+        </div>
+    </CarouselSlider.Slide>
+    ))}
+</CarouselSlider>

--- a/apps/docs/data/components/carousel/carousel.md
+++ b/apps/docs/data/components/carousel/carousel.md
@@ -33,6 +33,10 @@ import Carousel from '@comfortdelgro/react-compass/carousel'
 
 {{"demo": "CarouselMobile.tsx"}}
 
+### Multiple Slides
+
+{{"demo": "MultipleSlides.tsx"}}
+
 ## Components
 
 | Name                      | Type        | Default | Description                                                                       |
@@ -58,6 +62,7 @@ import Carousel from '@comfortdelgro/react-compass/carousel'
 | Name                 | Type                     | Default | Description                                                                              |
 | :------------------- | :----------------------- | :------ | :--------------------------------------------------------------------------------------- |
 | autoSwitch           | `boolean`                | `true`  | To let the slider auto switch in every 300ms                                             |
+| itemPerPage          | `number`                 | `1`     | How many slides on the same page                                                         |
 | useNavigation        | `boolean`                | `true`  | To show next and previous buttons                                                        |
 | useDotIndicator      | `boolean`                | `true`  | To show dot indicators                                                                   |
 | navigationButtonType | `icon` `text`            | `icon`  | To use arrow icon or next & prev text                                                    |

--- a/apps/docs/data/components/carousel/carousel.md
+++ b/apps/docs/data/components/carousel/carousel.md
@@ -35,6 +35,10 @@ import Carousel from '@comfortdelgro/react-compass/carousel'
 
 ### Multiple Slides
 
+Based on real life usage, every pages will have different behavior of responsive, how much items on single page. So that we expose everything to the outside to let the user custom them.
+
+You will need to handle how much items on same page based on screen size, or even container size. This config will need to be matched with side item width.
+
 {{"demo": "MultipleSlides.tsx"}}
 
 ## Components

--- a/apps/docs/data/components/carousel/sample.module.css
+++ b/apps/docs/data/components/carousel/sample.module.css
@@ -1,0 +1,22 @@
+.myMultipleSlidesSlider:global(.content-slider .slider-side.responsive-slide) {
+  display: flex;
+  height: 100%;
+  width: 33.33%;
+}
+
+.sampleSlideInner {
+  background-color: #ccc;
+  border: 1px solid #aaa;
+  width: 100%;
+  height: 250px;
+}
+
+@media screen and (max-width: 768px) {
+  .myMultipleSlidesSlider:global(
+      .content-slider .slider-side.responsive-slide
+    ) {
+    display: flex;
+    height: 100%;
+    width: 100%;
+  }
+}

--- a/packages/react-compass/src/carousel/carousel-slider.tsx
+++ b/packages/react-compass/src/carousel/carousel-slider.tsx
@@ -34,6 +34,7 @@ interface Props extends StyledComponentProps {
   socials?: SocicalIcon[]
   className?: string
   effect?: AnimationType
+  itemPerPage?: number
   onSwitchSlide?: (index: number) => void
 }
 
@@ -51,6 +52,7 @@ const CarouselSlider = React.forwardRef<HTMLDivElement, CarouselSliderProps>(
       socials,
       className,
       effect = 'fade',
+      itemPerPage = 1,
       css = {},
       onSwitchSlide = () => null,
       ...delegated
@@ -67,6 +69,7 @@ const CarouselSlider = React.forwardRef<HTMLDivElement, CarouselSliderProps>(
     const targetXPosition =
       (sliderRef.current && sliderRef.current.clientWidth * current) || 0
     const slideWidth = (sliderRef.current && sliderRef.current.clientWidth) || 0
+    const pageCount = children.length / itemPerPage
 
     useEffect(() => {
       const handleResize = () => {
@@ -77,7 +80,7 @@ const CarouselSlider = React.forwardRef<HTMLDivElement, CarouselSliderProps>(
       return () => {
         window.removeEventListener('resize', handleResize)
       }
-    }, [])
+    }, [current, sliderRef])
 
     useEffect(() => {
       if (autoSwitch) {
@@ -100,13 +103,14 @@ const CarouselSlider = React.forwardRef<HTMLDivElement, CarouselSliderProps>(
 
     const next = () => {
       clearCurrentTimer()
-      const nextIndex = (current + 1) % children.length
+      const nextIndex = (current + 1) % pageCount
       setCurrent(nextIndex)
     }
 
     const prev = () => {
+      console.log(pageCount)
       clearCurrentTimer()
-      const nextIndex = (current - 1 + children.length) % children.length
+      const nextIndex = (current - 1 + pageCount) % pageCount
       setCurrent(nextIndex)
     }
 
@@ -194,7 +198,7 @@ const CarouselSlider = React.forwardRef<HTMLDivElement, CarouselSliderProps>(
             children
           )}
         </StyledCarouselSliderContainer>
-        {useNavigation && children.length > 1 && (
+        {useNavigation && pageCount > 1 && (
           <div className='content-slider-controls'>
             <StyledCarouselSliderPrev
               onClick={prev}
@@ -233,9 +237,9 @@ const CarouselSlider = React.forwardRef<HTMLDivElement, CarouselSliderProps>(
             socials && socials.length ? ' use-socials' : ''
           }`}
         >
-          {useDotIndicator && children.length > 1 && (
+          {useDotIndicator && pageCount > 1 && (
             <CarouselSliderDots
-              length={children.length}
+              length={pageCount}
               current={current}
               dotClick={setCurrentIndex}
             />

--- a/packages/react-compass/src/carousel/carousel-slider.tsx
+++ b/packages/react-compass/src/carousel/carousel-slider.tsx
@@ -80,7 +80,7 @@ const CarouselSlider = React.forwardRef<HTMLDivElement, CarouselSliderProps>(
       return () => {
         window.removeEventListener('resize', handleResize)
       }
-    }, [current, sliderRef])
+    }, [])
 
     useEffect(() => {
       if (autoSwitch) {

--- a/packages/react-compass/src/carousel/carousel-slider.tsx
+++ b/packages/react-compass/src/carousel/carousel-slider.tsx
@@ -108,7 +108,6 @@ const CarouselSlider = React.forwardRef<HTMLDivElement, CarouselSliderProps>(
     }
 
     const prev = () => {
-      console.log(pageCount)
       clearCurrentTimer()
       const nextIndex = (current - 1 + pageCount) % pageCount
       setCurrent(nextIndex)

--- a/packages/react-compass/src/carousel/carousel.stories.tsx
+++ b/packages/react-compass/src/carousel/carousel.stories.tsx
@@ -1,6 +1,6 @@
 import {faBug} from '@fortawesome/free-solid-svg-icons'
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome'
-import React, {useState} from 'react'
+import React, {useEffect, useState} from 'react'
 import {styled} from '../theme'
 import CarouselMobile from './carousel-mobile'
 import CarouselPromotion from './carousel-promotion'
@@ -12,6 +12,7 @@ import {
   CarouselSliderItem,
   SocicalIcon,
 } from './content-slider.types'
+import './stories.css'
 
 const socials: SocicalIcon[] = [
   {
@@ -98,6 +99,7 @@ export const Sliders = () => {
   const [activeIndex, setActiveIndex] = useState(0)
   const [activeIndex1, setActiveIndex1] = useState(0)
   const [activeIndex2, setActiveIndex2] = useState(0)
+  const [count, setCount] = useState(3)
 
   const imageUrls = [
     'https://mdbcdn.b-cdn.net/img/Photos/Slides/img%20(15).webp',
@@ -117,6 +119,18 @@ export const Sliders = () => {
     setActiveIndex2(index)
   }
 
+  useEffect(() => {
+    const handleResize = () => {
+      const itemPerpage = window.innerWidth >= 768 ? 3 : 1
+      setCount(itemPerpage)
+    }
+    window.addEventListener('resize', handleResize)
+
+    return () => {
+      window.removeEventListener('resize', handleResize)
+    }
+  }, [])
+
   return (
     <>
       <StyledSampleAnyCarouselSlider className='content-slider-sample'>
@@ -125,31 +139,18 @@ export const Sliders = () => {
         <CarouselSlider
           onSwitchSlide={handleSwitchSlide2}
           effect={'slide'}
-          className='floating-slide'
-          itemPerPage={3}
-          style={{height: '512px'}}
+          className='my-multiple-slides-slider'
+          itemPerPage={count}
         >
           {Array.from({length: 9}).map((item, index) => (
             <CarouselSlide
               key={index}
-              className={`slider-side${
+              className={`slider-side responsive-slide${
                 activeIndex2 === index ? ' active' : ''
               }`}
               active={false}
-              css={{
-                width: '33.33% !important',
-                padding: '0 20px',
-              }}
             >
-              <div
-                style={{
-                  backgroundColor: '#ccc',
-                  border: '1px solid #aaa',
-                  height: '100%',
-                }}
-              >
-                Carousel slide {index}
-              </div>
+              <div className='sample-slide-inner'>Carousel slide {index}</div>
             </CarouselSlide>
           ))}
         </CarouselSlider>

--- a/packages/react-compass/src/carousel/carousel.stories.tsx
+++ b/packages/react-compass/src/carousel/carousel.stories.tsx
@@ -97,6 +97,7 @@ const slideData: CarouselSliderItem[] = [
 export const Sliders = () => {
   const [activeIndex, setActiveIndex] = useState(0)
   const [activeIndex1, setActiveIndex1] = useState(0)
+  const [activeIndex2, setActiveIndex2] = useState(0)
 
   const imageUrls = [
     'https://mdbcdn.b-cdn.net/img/Photos/Slides/img%20(15).webp',
@@ -112,8 +113,48 @@ export const Sliders = () => {
     setActiveIndex1(index)
   }
 
+  const handleSwitchSlide2 = (index: number) => {
+    setActiveIndex2(index)
+  }
+
   return (
     <>
+      <StyledSampleAnyCarouselSlider className='content-slider-sample'>
+        <h2>Slider - image only + no dots</h2>
+
+        <CarouselSlider
+          onSwitchSlide={handleSwitchSlide2}
+          effect={'slide'}
+          className='floating-slide'
+          itemPerPage={3}
+          style={{height: '512px'}}
+        >
+          {Array.from({length: 9}).map((item, index) => (
+            <CarouselSlide
+              key={index}
+              className={`slider-side${
+                activeIndex2 === index ? ' active' : ''
+              }`}
+              active={false}
+              css={{
+                width: '33.33% !important',
+                padding: '0 20px',
+              }}
+            >
+              <div
+                style={{
+                  backgroundColor: '#ccc',
+                  border: '1px solid #aaa',
+                  height: '100%',
+                }}
+              >
+                Carousel slide {index}
+              </div>
+            </CarouselSlide>
+          ))}
+        </CarouselSlider>
+      </StyledSampleAnyCarouselSlider>
+
       <StyledSampleAnyCarouselSlider className='content-slider-sample'>
         <h2>Slider - image only + no dots</h2>
 

--- a/packages/react-compass/src/carousel/stories.css
+++ b/packages/react-compass/src/carousel/stories.css
@@ -1,0 +1,20 @@
+.content-slider.my-multiple-slides-slider .slider-side.responsive-slide {
+  display: flex;
+  height: 100%;
+  width: 33.33%;
+}
+
+.sample-slide-inner {
+  background-color: #ccc;
+  border: 1px solid #aaa;
+  width: 100%;
+  height: 250px;
+}
+
+@media screen and (max-width: 768px) {
+  .content-slider.my-multiple-slides-slider .slider-side.responsive-slide {
+    display: flex;
+    height: 100%;
+    width: 100%;
+  }
+}


### PR DESCRIPTION
# Merge request description template

## Description

**1) Root cause**

Our carousel does not support user to customize how much items on a page


**2) Changes**

Add an option to help them to config how many items on a page

<img width="845" alt="Screenshot 2023-09-25 at 14 36 30" src="https://github.com/comfortdelgro/compass-design/assets/119040724/4d5064ff-674a-4c43-9d72-539f57a9a739">


**3) Impact**

No changes from the old implementation, newer will have more option.


## Reference (optional)
https://comfortdelgrotaxi.atlassian.net/browse/CDS-874



## Check list

- [x] 1. Did you start and verify your changes?
- [x] 2. Did you run build to make sure that your changes can be built successfully?
- [x] 3. No !important flag, inline style in css
- [x] 4. No boilerplate codes (1)
- [x] 5. No duplicate code that exist in common functions?
- [x] 6. All of defined variables should have default value, check null and undefined?
- [x] 7. Use meaningful name for variables, no suffix 1,2,... Describes reference information for easier to understand what's inside. (2)
- [x] 9. Unsubscribed all of subscribers and even listeners when you don't need them.

```
(1)
Boilerplate codes is duplicated multiple times a bunch of the same code. This should be a common function to reuse through your code or you can use generic class / methods or design pattern to avoid the Boilerplate codes.
```

```
(2)
Follow theo coding convention
NO acronym variable name:
WRONG: el, elm
RIGHT: element
Your code can be read as a sentence
```
