### PR TITLE
[CDS-952] loading icon position safari

### DIFF
--- a/packages/react-compass/src/table-v2/loading/loading-component.styles.tsx
+++ b/packages/react-compass/src/table-v2/loading/loading-component.styles.tsx
@@ -1,9 +1,8 @@
 import {styled} from '../../theme'
 
 export const StyledLoadingComponent = styled('tr', {
-  height: '$75',
   td: {
-    height: '100%',
+    height: '$75',
     margin: 'auto',
     textAlign: 'center',
   },


### PR DESCRIPTION
# Merge request description template

## Description

**1) Root cause**

Table row tag (tr) in Safari may not receive the height. I moved the height to the td element containing the loading indicator.

**2) Changes**

![image](https://github.com/comfortdelgro/compass-design/assets/7071853/c2026747-e10b-40c0-92fd-6c54234632a4)

**3) Impact**

<!-- Impact to function, screen or module -->

## Reference (optional)

<!-- Link to JIRA -->

## Check list

- [x] 1. Did you start and verify your changes?
- [x] 2. Did you run build to make sure that your changes can be built successfully?
- [x] 3. No !important flag, inline style in css
- [x] 4. No boilerplate codes (1)
- [x] 5. No duplicate code that exist in common functions?
- [x] 6. All of defined variables should have default value, check null and undefined?
- [x] 7. Use meaningful name for variables, no suffix 1,2,... Describes reference information for easier to understand what's inside. (2)
- [x] 9. Unsubscribed all of subscribers and even listeners when you don't need them.

```
(1)
Boilerplate codes is duplicated multiple times a bunch of the same code. This should be a common function to reuse through your code or you can use generic class / methods or design pattern to avoid the Boilerplate codes.
```

```
(2)
Follow theo coding convention
NO acronym variable name:
WRONG: el, elm
RIGHT: element
Your code can be read as a sentence
```
