### PR TITLE
fix: PUDO swap svg icon styles

### DIFF
--- a/packages/static/src/pudo/styles/pudo.module.css
+++ b/packages/static/src/pudo/styles/pudo.module.css
@@ -134,7 +134,7 @@
       cursor: pointer;
       z-index: 1;
 
-      svg {
+      & svg {
         display: block;
       }
 
@@ -272,7 +272,9 @@
     }
 
     &::after {
-      height: calc(100% - var(--cdg-pudo-icon-height) * 2 + var(--cdg-pudo-dot-size));
+      height: calc(
+        100% - var(--cdg-pudo-icon-height) * 2 + var(--cdg-pudo-dot-size)
+      );
     }
   }
 }


### PR DESCRIPTION
## Description

**1) Root cause**

CSS nesting: for now it needs to add `&` before the svg tag

**2) Changes**

PUDO's swap svg icon

**3) Impact**

PUDO component

## Check list

- [x] 1. Did you start and verify your changes?
- [x] 2. Did you run build to make sure that your changes can be built successfully?
- [x] 3. No !important flag, inline style in css
- [x] 4. No boilerplate codes (1)
- [x] 5. No duplicate code that exist in common functions?
- [x] 6. All of defined variables should have default value, check null and undefined?
- [x] 7. Use meaningful name for variables, no suffix 1,2,... Describes reference information for easier to understand what's inside. (2)
- [x] 9. Unsubscribed all of subscribers and even listeners when you don't need them.

```
(1)
Boilerplate codes is duplicated multiple times a bunch of the same code. This should be a common function to reuse through your code or you can use generic class / methods or design pattern to avoid the Boilerplate codes.
```

```
(2)
Follow theo coding convention
NO acronym variable name:
WRONG: el, elm
RIGHT: element
Your code can be read as a sentence
```
