### PR TITLE
Drawer - Add ability to programmatically collapse the drawer

### DIFF
--- a/apps/docs/data/components/drawer/DrawerCollapseRef.tsx
+++ b/apps/docs/data/components/drawer/DrawerCollapseRef.tsx
@@ -1,0 +1,54 @@
+import {
+  Button,
+  Column,
+  Drawer,
+  DrawerRef,
+  Row,
+  Typography,
+} from '@comfortdelgro/react-compass-old'
+import {useRef, useState} from 'react'
+
+export default function DrawerCollapseRefDocs() {
+  const [openDrawer, setOpenDrawer] = useState(false)
+  const [isExpanded, setIsExpanded] = useState(false)
+  const drawerRef = useRef<DrawerRef>(null)
+
+  return (
+    <Column>
+      <Typography.Header variant='header4'>1. Use ref</Typography.Header>
+      <Typography.Body
+        variant='body2'
+        css={{'&>code': {fontFamily: '$mono', fontWeight: '$semibold'}}}
+      >
+        Use <code>ref</code> to call the Drawer's <code>triggerCollapse</code>{' '}
+        function
+      </Typography.Body>
+      <Row css={{marginBlock: '$4'}}>
+        <Button type='button' onClick={() => setOpenDrawer(true)}>
+          Open H5 Drawer
+        </Button>
+      </Row>
+
+      <Drawer
+        ref={drawerRef}
+        open={openDrawer}
+        variant='h5'
+        onExpandChange={(isExpanded) => setIsExpanded(isExpanded)}
+        onHeightChange={(height) => console.log('height', height)}
+        onClose={() => setOpenDrawer(false)}
+      >
+        <Drawer.Header>
+          Get drawer's parameters and collapse it programmatically
+        </Drawer.Header>
+
+        <Button
+          css={{marginTop: '$4'}}
+          type='button'
+          onClick={() => drawerRef.current?.triggerCollapse()}
+        >
+          Collapse this drawer
+        </Button>
+      </Drawer>
+    </Column>
+  )
+}

--- a/apps/docs/data/components/drawer/DrawerCollapseRef.tsx.preview
+++ b/apps/docs/data/components/drawer/DrawerCollapseRef.tsx.preview
@@ -1,0 +1,12 @@
+import {Drawer, DrawerRef, Button} from '@comfortdelgro/react-compass'
+
+const drawerRef = useRef<DrawerRef>(null)
+
+<Drawer
+  ref={drawerRef}
+  variant='h5'
+>
+  <Button type='button' onClick={() => drawerRef.current?.triggerCollapse()}>
+    Collapse this drawer
+  </Button>
+</Drawer>

--- a/apps/docs/data/components/drawer/DrawerExpose.tsx
+++ b/apps/docs/data/components/drawer/DrawerExpose.tsx
@@ -1,0 +1,80 @@
+import {
+  Button,
+  Column,
+  Drawer,
+  Row,
+  Typography,
+} from '@comfortdelgro/react-compass-old'
+import {useState} from 'react'
+
+export default function DrawerExposeDocs() {
+  const [openDrawer, setOpenDrawer] = useState(false)
+
+  return (
+    <Column>
+      <Typography.Header variant='header4'>children as function</Typography.Header>
+      <Typography.Body
+        variant='body2'
+        css={{'&>code': {fontFamily: '$mono', fontWeight: '$semibold'}}}
+      >
+        When using this method, you pass children as a function which allows you
+        to access the <code>triggerCollapse</code> function and also some
+        Drawer's parameters too.
+        <br />
+        <br />
+        <strong>Note:</strong> you should wrap your Drawer's content inside a{' '}
+        <code>{'<Fragment>'}</code> otherwise, the content may appear
+        incorrectly.
+      </Typography.Body>
+      <Row css={{marginBlock: '$4'}}>
+        <Button type='button' onClick={() => setOpenDrawer(true)}>
+          Open H5 Drawer
+        </Button>
+      </Row>
+
+      <Drawer
+        variant='h5'
+        open={openDrawer}
+        expanderCSS={{
+          background: '$blueShades100',
+          paddingBlock: '$2 $6',
+        }}
+        onClose={() => setOpenDrawer(false)}
+      >
+        {({triggerCollapse, ...otherParameters}) => (
+          <>
+            <Drawer.Header
+              css={{
+                paddingTop: 0,
+                gap: '$2',
+                backgroundColor: '$blueShades100',
+              }}
+            >
+              <Typography.Header
+                variant='header5'
+                css={{color: '$grayShades10'}}
+              >
+                Get drawer's parameters and collapse it programmatically
+              </Typography.Header>
+            </Drawer.Header>
+            <pre
+              style={{
+                padding: '0.5rem',
+                width: '100%',
+                borderRadius: '8px',
+                backgroundColor: '#FAF9F8',
+                whiteSpace: 'pre-wrap',
+                overflowWrap: 'anywhere',
+              }}
+            >
+              {JSON.stringify(otherParameters, null, 4)}
+            </pre>
+            <Button css={{marginTop: '$4'}} onClick={() => triggerCollapse()}>
+              Collapse this drawer
+            </Button>
+          </>
+        )}
+      </Drawer>
+    </Column>
+  )
+}

--- a/apps/docs/data/components/drawer/DrawerExpose.tsx.preview
+++ b/apps/docs/data/components/drawer/DrawerExpose.tsx.preview
@@ -1,0 +1,14 @@
+import {Button, Drawer} from '@comfortdelgro/react-compass'
+
+<Drawer variant='h5'>
+  {({triggerCollapse, ...otherParameters}) => (
+    <>
+      <Drawer.Header>
+        Get drawer's parameters and collapse it programmatically
+      </Drawer.Header>
+      <Button type='button' onClick={() => triggerCollapse()}>
+        Collapse this drawer
+      </Button>
+    </>
+  )}
+</Drawer>

--- a/apps/docs/data/components/drawer/DrawerMode.tsx
+++ b/apps/docs/data/components/drawer/DrawerMode.tsx
@@ -95,14 +95,14 @@ export default function DrawerModeDocs() {
           <Typography.Body
             variant='body3'
             weight='semibold'
-            css={{color: '$grayShades10', width: 'fit-content'}}
+            css={{color: '$grayShades10', width: 'fit-content', margin: 0}}
           >
             Drawer Header
           </Typography.Body>
           <Typography.Body
             variant='body3'
             weight='semibold'
-            css={{color: '$grayShades10', width: 'fit-content'}}
+            css={{color: '$grayShades10', width: 'fit-content', margin: 0}}
           >
             Non-modal Mode
           </Typography.Body>

--- a/apps/docs/data/components/drawer/drawer.md
+++ b/apps/docs/data/components/drawer/drawer.md
@@ -20,21 +20,27 @@ or
 import Drawer from '@comfortdelgro/react-compass/drawer'
 ```
 
-## Usage
-
-### Basic
+## Basic
 
 {{"demo": "Drawer.tsx"}}
 
-### Positions
+## Positions
 
 {{"demo": "DrawerPosition.tsx"}}
 
-### H5 variant
+## H5 Drawer
 
 {{"demo": "DrawerH5.tsx"}}
 
-### Non-modal mode
+### Collapse the H5 drawer programmatically
+
+There are two ways to achieve it:
+
+{{"demo": "DrawerCollapseRef.tsx"}}
+
+{{"demo": "DrawerExpose.tsx"}}
+
+## Non-modal mode
 
 A Drawer that has no backdrop and also doesn't render on the top-layer. It can NOT be closed by pressing the `ESC` key.
 The content below the non-modal drawer can be interacted.
@@ -86,6 +92,7 @@ By default, it respects the default accessibility behavior and settings of a `<d
 | Name               | Type                          | Default                                                              | Description                                                                                                                                                                                                                                |
 | :----------------- | :---------------------------- | :------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `expanderCSS`      | `CSS`                         | —                                                                    | Allows to custom CSS styles for the expander (use for drag & drop).                                                                                                                                                                        |
+| `onHeightChange`   | `(height: number) => void`    | —                                                                    | Trigger when the H5 drawer's height changes.                                                                                                                                                                                               |
 | `onExpandChange`   | `(isExpand: boolean) => void` | —                                                                    | Trigger when the H5 drawer expanded.                                                                                                                                                                                                       |
 | `expandedPoint`    | `number`                      | `100` - <small>the top edge of available viewport</small>            | How many **percentage** of the viewport height that the drawer will be fully expanded.<br/><small>Accepted value range: `0` - `100`<br/>Must be greater than `expandableLine` and the drawer initialization height (percent).</small>      |
 | `expandableLine`   | `number`                      | `67` - <small>2/3 viewport from bottom of available viewport</small> | A boundary to tell the drawer to fully expand when its top crosses this line.<br/><small>Accepted value range: `0` - `100`<br/>It must be smaller than `expandedPoint` and greater than drawer initialization height (percentage).</small> |

--- a/packages/react-compass/src/drawer/drawer-pick-child.ts
+++ b/packages/react-compass/src/drawer/drawer-pick-child.ts
@@ -1,0 +1,48 @@
+import {
+  Children,
+  ElementType,
+  isValidElement,
+  PropsWithChildren,
+  ReactElement,
+  ReactNode,
+} from 'react'
+
+const processChildren = (children: ReactNode) => {
+  if (!isValidElement(children)) {
+    return children
+  }
+
+  const isFragment =
+    children.type.toString() === Symbol.for('react.fragment').toString()
+
+  if (isFragment) {
+    return (children.props as PropsWithChildren<unknown>)?.children || children
+  }
+
+  return children
+}
+
+export const drawerPickChild = <T = ReactNode>(
+  children: ReactNode,
+  targetType: ElementType,
+): {child: T | undefined; rest: ReactElement} => {
+  const matched: ReactNode[] = []
+
+  const rest = Children.map(processChildren(children), (item) => {
+    if (!isValidElement(item)) {
+      return item
+    }
+
+    if (item.type === targetType) {
+      matched.push(item)
+      return null
+    }
+    return item
+  })
+  const child = matched.length >= 0 ? matched[0] : undefined
+
+  return {
+    child: child as T,
+    rest: rest as unknown as ReactElement,
+  }
+}

--- a/packages/react-compass/src/drawer/drawer.stories.tsx
+++ b/packages/react-compass/src/drawer/drawer.stories.tsx
@@ -3,8 +3,9 @@ import ArrowRight from '@comfortdelgro/compass-icons/react/arrow-right'
 import CrossIcon from '@comfortdelgro/compass-icons/react/cross'
 import {faChevronRight, faFaceSmile} from '@fortawesome/free-solid-svg-icons'
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome'
-import React, {FormEventHandler, useState} from 'react'
+import React, {FormEventHandler, useRef, useState} from 'react'
 import Button from '../button'
+import Divider from '../divider'
 import Link from '../link'
 import List from '../list'
 import ListImage from '../list/list-image'
@@ -14,7 +15,7 @@ import {styled} from '../theme'
 import Typography from '../typography'
 import {Row} from '../utils'
 import {Column} from '../utils/components'
-import Drawer, {DrawerH5Props, DrawerProps} from './index'
+import Drawer, {DrawerH5Props, DrawerProps, DrawerRef} from './index'
 
 const imgSrc =
   'https://images.pexels.com/photos/777059/pexels-photo-777059.jpeg?auto=compress&cs=tinysrgb&dpr=1&w=500'
@@ -31,6 +32,11 @@ export function H5() {
   const [openNonModalDrawer, setOpenNonModalDrawer] = useState(false)
   const [openDemoTripDrawer, setOpenDemoTripDrawer] = useState(false)
   const [openConfirmModal, setOpenConfirmModal] = useState(false)
+
+  const collapseDrawerRef = useRef<DrawerRef>(null)
+  const [openTriggerCollapseDrawer, setOpenTriggerCollapseDrawer] =
+    useState(false)
+  const [openParameterDrawer, setOpenParameterDrawer] = useState(false)
 
   const [openNoFocusDrawer, setOpenNoFocusDrawer] = useState({
     open: false,
@@ -53,20 +59,6 @@ export function H5() {
         Open Customizable Drawer
       </Button>
 
-      <h4>Demo Trip information</h4>
-      <Typography.Body
-        variant='body3'
-        css={{color: '$grayShades60', marginBlock: '$2 $4'}}
-      >
-        Drawer's maximum expanded height will be half of current viewport with
-        autoclose disabled.
-        <br />
-        Better view on mobile screen
-      </Typography.Body>
-      <Button type='button' onClick={() => setOpenDemoTripDrawer(true)}>
-        Open Drawer
-      </Button>
-
       <h4>Non-modal mode</h4>
       <Typography.Body
         variant='body3'
@@ -85,6 +77,61 @@ export function H5() {
       >
         Toggle Non-modal Drawer
       </Button>
+
+      <h4>Drawer's parameters and manipulation</h4>
+      <Typography.Body
+        variant='body3'
+        css={{color: '$grayShades60', marginBlock: '$2 $4'}}
+      >
+        Get Drawer's parameters and programmatically collapse the drawer
+      </Typography.Body>
+
+      <div>
+        <Typography.Body variant='body2'>
+          There are two ways to achieve it.
+        </Typography.Body>
+
+        <h5>1. Use ref</h5>
+        <Typography.Body
+          variant='body2'
+          css={{'&>code': {fontWeight: '$semibold'}}}
+        >
+          Use <code>ref</code> to call the Drawer's <code>triggerCollapse</code>{' '}
+          function
+        </Typography.Body>
+        <Button
+          css={{marginBlock: '$4'}}
+          type='button'
+          onClick={() => setOpenTriggerCollapseDrawer(true)}
+        >
+          Open Drawer
+        </Button>
+
+        <Divider />
+
+        <h5>2. Children as function</h5>
+        <Typography.Body
+          variant='body2'
+          css={{'&>code': {fontWeight: '$semibold'}}}
+        >
+          When using this method, you pass children as a function which allows
+          you to access the <code>triggerCollapse</code> function and also some
+          Drawer's parameters too.
+          <br />
+          <br />
+          <strong>Note:</strong> you should wrap your Drawer's content inside a{' '}
+          <code>{'<Fragment>'}</code> otherwise, the content may appear
+          incorrectly.
+        </Typography.Body>
+        <Button
+          css={{marginBlock: '$4'}}
+          type='button'
+          onClick={() => setOpenParameterDrawer(true)}
+        >
+          Open Drawer
+        </Button>
+        <Divider />
+      </div>
 
       <h4>Disable autofocus on the first nested focusable element</h4>
       <Typography.Body
@@ -119,6 +166,20 @@ export function H5() {
         }
       >
         Open autofocus disabled Drawer
+      </Button>
+
+      <h4>Demo Trip information</h4>
+      <Typography.Body
+        variant='body3'
+        css={{color: '$grayShades60', marginBlock: '$2 $4'}}
+      >
+        Drawer's maximum expanded height will be half of current viewport with
+        autoclose disabled.
+        <br />
+        Better view on mobile screen
+      </Typography.Body>
+      <Button type='button' onClick={() => setOpenDemoTripDrawer(true)}>
+        Open Drawer
       </Button>
 
       <Drawer
@@ -462,6 +523,52 @@ export function H5() {
       </Drawer>
 
       <Drawer
+        ref={collapseDrawerRef}
+        open={openTriggerCollapseDrawer}
+        variant='h5'
+        onExpandChange={(isExpanded) => console.log(isExpanded)}
+        onHeightChange={(height) => console.log('height', height)}
+        onClose={() => setOpenTriggerCollapseDrawer(false)}
+      >
+        <Drawer.Header>
+          Get drawer's parameters and collapse it programmatically
+        </Drawer.Header>
+
+        <Button
+          css={{marginTop: '$4'}}
+          type='button'
+          onClick={() => collapseDrawerRef.current?.triggerCollapse()}
+        >
+          Collapse this drawer
+        </Button>
+      </Drawer>
+
+      <Drawer
+        open={openParameterDrawer}
+        variant='h5'
+        onClose={() => setOpenParameterDrawer(false)}
+      >
+        {({triggerCollapse, ...otherParameters}) => (
+          <>
+            <Drawer.Header>
+              Get drawer's parameters and collapse it programmatically
+            </Drawer.Header>
+
+            <PreviewCode>
+              {JSON.stringify(otherParameters, null, 4)}
+            </PreviewCode>
+            <Button
+              css={{marginTop: '$4'}}
+              type='button'
+              onClick={() => triggerCollapse()}
+            >
+              Collapse this drawer
+            </Button>
+          </>
+        )}
+      </Drawer>
+
+      <Drawer
         open={openNoFocusDrawer.open}
         css={{height: '30dvh'}}
         onClose={() => setOpenNoFocusDrawer({open: false, preventFocus: false})}
@@ -802,4 +909,18 @@ const StyledContainer = styled('div', {
   'h4 + button': {
     marginTop: '$4',
   },
+})
+
+const PreviewCode = styled('pre', {
+  padding: '$2',
+  margin: '0',
+
+  width: '100%',
+  minHeight: '$5',
+  borderRadius: '$lg',
+
+  backgroundColor: '$secondaryBg',
+  fontSize: '$label1',
+  whiteSpace: 'pre-wrap',
+  overflowWrap: 'anywhere',
 })

--- a/packages/react-compass/src/drawer/index.ts
+++ b/packages/react-compass/src/drawer/index.ts
@@ -4,7 +4,12 @@ import DrawerHeader from './drawer-header'
 
 export type {DrawerFooterProps} from './drawer-footer'
 export type {DrawerHeaderProps} from './drawer-header'
-export type {DrawerDefaultProps, DrawerH5Props, DrawerProps} from './types'
+export type {
+  DrawerDefaultProps,
+  DrawerH5Props,
+  DrawerProps,
+  DrawerRef,
+} from './types'
 
 Drawer.Header = DrawerHeader
 Drawer.Footer = DrawerFooter

--- a/packages/react-compass/src/drawer/types.ts
+++ b/packages/react-compass/src/drawer/types.ts
@@ -1,4 +1,4 @@
-import {DialogHTMLAttributes} from 'react'
+import {DialogHTMLAttributes, ReactNode} from 'react'
 import {StyledComponentProps} from '../utils/stitches.types'
 import {DrawerVariantProps} from './drawer.styles'
 
@@ -45,12 +45,26 @@ interface DefaultDrawerProps {
 
   expanderCSS?: never
   onExpandChange?: never
+  onHeightChange?: never
   expandedPoint?: never
   expandableLine?: never
   disableResize?: never
-  disableAddBodyAttr?: never
   disableDragClose?: never
 }
+
+type H5DrawerChildrenAsFunctionOptions = {
+  triggerCollapse: () => void
+  isExpanded: boolean
+  height: number
+} & Omit<
+  H5DrawerProps,
+  | 'variant'
+  | 'position'
+  | 'expanderCSS'
+  | 'onExpandChange'
+  | 'onHeightChange'
+  | 'children'
+>
 
 interface H5DrawerProps {
   variant: 'h5'
@@ -87,18 +101,6 @@ interface H5DrawerProps {
   disableResize?: boolean
 
   /**
-   * @deprecated This property now becomes useless, does nothing and will be removed in the next major release.
-   *
-   * Now respect the `<dialog />`'s default behaviors, let the browsers control if the content page below the Drawer should be rendered inert or not.
-   * ___
-   * @description
-   * if `true`, when open a drawer, it will NOT
-   *  add {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inert inert} attribute and `overflow: hidden` to the `<body>` tag.
-   * @default false
-   */
-  disableAddBodyAttr?: boolean
-
-  /**
    * Close the H5 drawer if the user drags and drops it below the default height.
    *
    * Note that if `disableResize` is true, users can't drag the the drawer.
@@ -106,6 +108,12 @@ interface H5DrawerProps {
    * @default false
    */
   disableDragClose?: boolean
+
+  onHeightChange?: (height: number) => void
+
+  children?:
+    | ReactNode
+    | ((options: H5DrawerChildrenAsFunctionOptions) => ReactNode)
 }
 
 export type DrawerH5Props = DrawerSharedProps & H5DrawerProps
@@ -121,3 +129,7 @@ export type DrawerProps = Props &
     DialogHTMLAttributes<HTMLDialogElement>,
     keyof Props | 'tabIndex' | 'autoFocus'
   >
+
+export type DrawerRef = HTMLDialogElement & {
+  triggerCollapse: () => void
+}

--- a/packages/react-compass/src/index.ts
+++ b/packages/react-compass/src/index.ts
@@ -96,6 +96,7 @@ export type {
   DrawerH5Props,
   DrawerHeaderProps,
   DrawerProps,
+  DrawerRef,
 } from './drawer'
 export {default as Dropdown} from './dropdown'
 export type {
@@ -161,9 +162,9 @@ export type {LayoutProps} from './layouts'
 export {default as Link} from './link'
 export type {LinkProps} from './link'
 export {
+  default as List,
   DragAndDropList,
   InteractiveList,
-  default as List,
   ListCard,
 } from './list'
 export type {
@@ -259,8 +260,8 @@ export type {
 } from './sidebar'
 export {default as Sidenav, SidenavContext} from './sidenav'
 export type {
-  SidenavContextValue,
   DividerProps as SidenavDividerProps,
+  SidenavContextValue,
   SidenavItemProps,
   SidenavMenuProps,
   SidenavProps,
@@ -354,8 +355,8 @@ export type {
 export {ToastContextProvider, useToast} from './toast/service'
 export type {
   ToastItemType,
-  ToastState,
   ToastsContainerProps,
+  ToastState,
 } from './toast/service'
 export {default as Toggle} from './toggle'
 export type {ToggleProps} from './toggle'

--- a/packages/static/src/drawer/Drawer.stories.tsx
+++ b/packages/static/src/drawer/Drawer.stories.tsx
@@ -5,10 +5,11 @@ import {
 } from '@fortawesome/free-solid-svg-icons'
 // import {faChevronRight} from '@fortawesome/free-solid-svg-icons/faChevronRight'
 import {Meta} from '@storybook/react'
-import {FormEventHandler, useState} from 'react'
+import {FormEventHandler, useRef, useState} from 'react'
+import {Divider, Modal, Typography} from '..'
 import Button from '../button'
 import Icon from '../icon'
-import Drawer, {DrawerH5Props, DrawerProps} from './index'
+import Drawer, {DrawerH5Props, DrawerProps, DrawerRef} from './index'
 import storiesStyles from './styles/drawer-stories.module.css'
 
 export function Default() {
@@ -53,11 +54,7 @@ export function Default() {
       <h4>Drawer</h4>
       <p>Drawer form value: {keyword}</p>
 
-      <Button
-        css={{marginBlock: '$4'}}
-        type='button'
-        onClick={() => setOpenDrawer(true)}
-      >
+      <Button type='button' onClick={() => setOpenDrawer(true)}>
         Open Drawer
       </Button>
 
@@ -297,9 +294,14 @@ const h5DrawerDefaultConfig: Partial<DrawerH5Props> = {
 export function H5() {
   const [openDrawer, setOpenDrawer] = useState(false)
   const [openDemoDrawer, setOpenDemoDrawer] = useState(false)
-  // const [openNonModalDrawer, setOpenNonModalDrawer] = useState(false)
+  const [openNonModalDrawer, setOpenNonModalDrawer] = useState(false)
   // const [openDemoTripDrawer, setOpenDemoTripDrawer] = useState(false)
-  // const [openConfirmModal, setOpenConfirmModal] = useState(false)
+  const [openConfirmModal, setOpenConfirmModal] = useState(false)
+
+  const collapseDrawerRef = useRef<DrawerRef>(null)
+  const [openTriggerCollapseDrawer, setOpenTriggerCollapseDrawer] =
+    useState(false)
+  const [openParameterDrawer, setOpenParameterDrawer] = useState(false)
 
   const [openNoFocusDrawer, setOpenNoFocusDrawer] = useState({
     open: false,
@@ -322,7 +324,7 @@ export function H5() {
         Open Customizable Drawer
       </Button>
 
-      {/* <h4>Non-modal mode</h4>
+      <h4>Non-modal mode</h4>
       <p className={storiesStyles.description}>
         A Drawer that has no backdrop and also doesn't render on the top-layer.
         It can <strong>NOT</strong> be closed by pressing the <kbd>ESC</kbd>{' '}
@@ -336,7 +338,47 @@ export function H5() {
         onClick={() => setOpenNonModalDrawer(!openNonModalDrawer)}
       >
         Toggle Non-modal Drawer
-      </Button> */}
+      </Button>
+
+      <h4>Drawer's parameters and manipulation</h4>
+      <p className={storiesStyles.description}>
+        Get Drawer's parameters and programmatically collapse the drawer
+      </p>
+
+      <div>
+        <Typography.Body variant='body2'>
+          There are two ways to achieve it:
+        </Typography.Body>
+
+        <h5>1. Use ref</h5>
+        <Typography.Body variant='body2'>
+          Use <code>ref</code> to call the Drawer's <code>triggerCollapse</code>{' '}
+          function
+        </Typography.Body>
+        <Button
+          type='button'
+          onClick={() => setOpenTriggerCollapseDrawer(true)}
+        >
+          Open Drawer
+        </Button>
+
+        <Divider css={{marginTop: '1rem'}} />
+
+        <h5>2. Children as function</h5>
+        <Typography.Body variant='body2'>
+          When using this method, you pass children as a function which allows
+          you to access the <code>triggerCollapse</code> function and also some
+          Drawer's parameters too.
+          <br />
+          <br />
+          <strong>Note:</strong> you should wrap your Drawer's content inside a{' '}
+          <code>{'<Fragment/>'}</code> otherwise, the content may appear
+          incorrectly.
+        </Typography.Body>
+        <Button type='button' onClick={() => setOpenParameterDrawer(true)}>
+          Open Drawer
+        </Button>
+      </div>
 
       <h4>Disable autofocus on the first nested focusable element</h4>
       <p className={storiesStyles.description}>
@@ -457,40 +499,21 @@ export function H5() {
         )}
       </Drawer>
 
-      {/* <Drawer
+      <Drawer
+        className={storiesStyles.drawerH5Example}
         open={openNonModalDrawer}
         css={{height: '30dvh'}}
-        expanderCSS={{
-          background: 'var(--cdg-color-blueShades100)',
-          paddingBlock: '$2 $6',
-        }}
         onClose={() => setOpenNonModalDrawer(false)}
         variant='h5'
         expandedPoint={80}
         expandableLine={60}
         drawerMode='non-modal'
       >
-        <Drawer.Header
-          css={{
-            display: 'flex',
-            paddingTop: 0,
-            gap: '$2',
-            justifyContent: 'space-between',
-            backgroundColor: 'var(--cdg-color-blueShades100)',
-          }}
-        >
-          <Typography.Body
-            variant='body3'
-            weight='semibold'
-            css={{color: 'var(--cdg-color-grayShades10)', width: 'fit-content'}}
-          >
+        <Drawer.Header>
+          <Typography.Body variant='body3' weight='semibold'>
             Your ride is on the way
           </Typography.Body>
-          <Typography.Body
-            variant='body3'
-            weight='semibold'
-            css={{color: 'var(--cdg-color-grayShades10)', width: 'fit-content'}}
-          >
+          <Typography.Body variant='body3' weight='semibold'>
             Arriving in 8 - 10 min
           </Typography.Body>
         </Drawer.Header>
@@ -545,7 +568,51 @@ export function H5() {
             </Modal.Actions>
           </Modal>
         </Modal.Trigger>
-      </Drawer> */}
+      </Drawer>
+
+      <Drawer
+        ref={collapseDrawerRef}
+        open={openTriggerCollapseDrawer}
+        variant='h5'
+        onExpandChange={(isExpanded) => console.log(isExpanded)}
+        onHeightChange={(height) => console.log('height', height)}
+        onClose={() => setOpenTriggerCollapseDrawer(false)}
+      >
+        <Drawer.Header>
+          Get drawer's parameters and collapse it programmatically
+        </Drawer.Header>
+
+        <Button
+          type='button'
+          onClick={() => collapseDrawerRef.current?.triggerCollapse()}
+        >
+          Collapse this drawer
+        </Button>
+      </Drawer>
+
+      <Drawer
+        className={storiesStyles.drawerH5Example}
+        open={openParameterDrawer}
+        variant='h5'
+        onClose={() => setOpenParameterDrawer(false)}
+      >
+        {({triggerCollapse, ...otherParameters}) => (
+          <>
+            <Drawer.Header>
+              <Typography.Body variant='body3' weight='semibold'>
+                Get drawer's parameters and collapse it programmatically
+              </Typography.Body>
+            </Drawer.Header>
+
+            <pre className={storiesStyles.previewCode}>
+              {JSON.stringify(otherParameters, null, 4)}
+            </pre>
+            <Button type='button' onClick={() => triggerCollapse()}>
+              Collapse this drawer
+            </Button>
+          </>
+        )}
+      </Drawer>
 
       <Drawer
         open={openNoFocusDrawer.open}

--- a/packages/static/src/drawer/drawer-pick-child.ts
+++ b/packages/static/src/drawer/drawer-pick-child.ts
@@ -1,0 +1,48 @@
+import {
+  Children,
+  ElementType,
+  isValidElement,
+  PropsWithChildren,
+  ReactElement,
+  ReactNode,
+} from 'react'
+
+const processChildren = (children: ReactNode) => {
+  if (!isValidElement(children)) {
+    return children
+  }
+
+  const isFragment =
+    children.type.toString() === Symbol.for('react.fragment').toString()
+
+  if (isFragment) {
+    return (children.props as PropsWithChildren<unknown>)?.children || children
+  }
+
+  return children
+}
+
+export const drawerPickChild = <T = ReactNode>(
+  children: ReactNode,
+  targetType: ElementType,
+): {child: T | undefined; rest: ReactElement} => {
+  const matched: ReactNode[] = []
+
+  const rest = Children.map(processChildren(children), (item) => {
+    if (!isValidElement(item)) {
+      return item
+    }
+
+    if (item.type === targetType) {
+      matched.push(item)
+      return null
+    }
+    return item
+  })
+  const child = matched.length >= 0 ? matched[0] : undefined
+
+  return {
+    child: child as T,
+    rest: rest as unknown as ReactElement,
+  }
+}

--- a/packages/static/src/drawer/drawer.tsx
+++ b/packages/static/src/drawer/drawer.tsx
@@ -8,22 +8,23 @@ import {
   ReactEventHandler,
   useCallback,
   useEffect,
+  useImperativeHandle,
   useMemo,
   useState,
 } from 'react'
 import CssInjection from '../utils/objectToCss/CssInjection'
-import {pickChild} from '../utils/pick-child'
 import {useDOMRef} from '../utils/use-dom-ref'
 import DrawerExpander, {DrawerExpanderProps} from './drawer-expander'
 import DrawerFooter from './drawer-footer'
 import DrawerHeader from './drawer-header'
+import {drawerPickChild} from './drawer-pick-child'
 import drawerStyles from './styles/drawer.module.css'
-import {DrawerProps} from './types'
+import {DrawerProps, DrawerRef} from './types'
 
 const DEFAULT_EXPANDED_POINT = 100
 const DEFAULT_EXPANDABLE_LINE = 67
 
-const Drawer = forwardRef<HTMLDialogElement, DrawerProps>((props, ref) => {
+const Drawer = forwardRef<DrawerRef, DrawerProps>((props, ref) => {
   const viewPortHeight =
     typeof window !== 'undefined' ? window.innerHeight : undefined
 
@@ -46,14 +47,11 @@ const Drawer = forwardRef<HTMLDialogElement, DrawerProps>((props, ref) => {
     // H5 drawer props
     expanderCSS = {},
     onExpandChange,
+    onHeightChange,
     expandedPoint: expandPoint = DEFAULT_EXPANDED_POINT,
     expandableLine: expandLine = DEFAULT_EXPANDABLE_LINE,
     disableResize = false,
     disableDragClose = false,
-
-    // @todo remove the deprecated "disableAddBodyAttr" flag on next major release.
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    disableAddBodyAttr: _,
 
     // the rest
     ...htmlDialogAttributes
@@ -61,12 +59,14 @@ const Drawer = forwardRef<HTMLDialogElement, DrawerProps>((props, ref) => {
 
   const position: DrawerProps['position'] =
     variant === 'h5' ? 'bottom' : drawerPosition
-  const DrawerRef = useDOMRef<HTMLDialogElement>(ref)
+  const DrawerRef = useDOMRef<DrawerRef>(ref)
   const DrawerElement = DrawerRef.current
 
   const [drawerInitHeight, setDrawerInitHeight] = useState(0)
   const [drawerStartingHeight, setDrawerStartingHeight] = useState<number>()
-  const [drawerHeight, setDrawerHeight] = useState(DrawerElement?.offsetHeight)
+  const [drawerHeight, setDrawerHeight] = useState(
+    DrawerElement?.offsetHeight || 0,
+  )
   const [isExpanded, setIsExpanded] = useState(false)
 
   const {expandedPosition, expandablePosition} = useMemo(() => {
@@ -101,13 +101,6 @@ const Drawer = forwardRef<HTMLDialogElement, DrawerProps>((props, ref) => {
     }
   }, [expandPoint, expandLine, viewPortHeight, drawerInitHeight])
 
-  const {child: DrawerHeaderElement, rest: OtherElementsExceptHeader} =
-    pickChild<typeof DrawerHeader>(children, DrawerHeader)
-
-  const {child: DrawerFooterElement, rest: OtherElements} = pickChild<
-    typeof DrawerFooter
-  >(OtherElementsExceptHeader, DrawerFooter)
-
   const handleCloseDrawer = useCallback(
     (dialogReturnValue?: string) => {
       if (typeof document === 'undefined' || !DrawerElement) {
@@ -115,6 +108,7 @@ const Drawer = forwardRef<HTMLDialogElement, DrawerProps>((props, ref) => {
       }
 
       setDrawerHeight(drawerInitHeight)
+      setDrawerStartingHeight(drawerInitHeight)
       DrawerElement.close(dialogReturnValue)
     },
     [DrawerElement, drawerInitHeight],
@@ -172,8 +166,9 @@ const Drawer = forwardRef<HTMLDialogElement, DrawerProps>((props, ref) => {
       }
 
       setDrawerHeight(newHeight - y)
+      onHeightChange?.(newHeight - y)
     },
-    [DrawerElement, drawerInitHeight, drawerStartingHeight],
+    [DrawerElement, drawerInitHeight, drawerStartingHeight, onHeightChange],
   )
 
   const handleExpanderDragEnd = useCallback<
@@ -194,7 +189,11 @@ const Drawer = forwardRef<HTMLDialogElement, DrawerProps>((props, ref) => {
       const newHeight = referenceHeight - dragPosition.y
       const isCrossExpandLine = newHeight > expandablePosition
       setIsExpanded(isCrossExpandLine)
-      onExpandChange?.(isCrossExpandLine)
+
+      if (isExpanded !== isCrossExpandLine) {
+        onExpandChange?.(isCrossExpandLine)
+      }
+
       setPositionOnEnd({x: 0, y: 0})
 
       if (
@@ -227,6 +226,46 @@ const Drawer = forwardRef<HTMLDialogElement, DrawerProps>((props, ref) => {
     ],
   )
 
+  const triggerCollapse = () => {
+    if (!isExpanded) {
+      return
+    }
+
+    setIsExpanded(false)
+    onExpandChange?.(false)
+    onHeightChange?.(drawerInitHeight)
+    setDrawerStartingHeight(drawerInitHeight)
+    setDrawerHeight(drawerInitHeight)
+  }
+
+  useImperativeHandle(ref, () => ({
+    ...DrawerElement!,
+    triggerCollapse,
+  }))
+
+  const renderChildren = () => {
+    if (variant === 'h5' && typeof children === 'function') {
+      return children({
+        triggerCollapse,
+        height: drawerHeight,
+        isExpanded,
+        expandedPoint: expandedPosition,
+        expandableLine: expandablePosition,
+        disableResize,
+        disableDragClose,
+      })
+    }
+
+    return children
+  }
+
+  const {child: DrawerHeaderElement, rest: OtherElementsExceptHeader} =
+    drawerPickChild<typeof DrawerHeader>(renderChildren(), DrawerHeader)
+
+  const {child: DrawerFooterElement, rest: OtherElements} = drawerPickChild<
+    typeof DrawerFooter
+  >(OtherElementsExceptHeader, DrawerFooter)
+
   useEffect(() => {
     if (typeof document === 'undefined' || !DrawerElement) {
       return
@@ -245,10 +284,7 @@ const Drawer = forwardRef<HTMLDialogElement, DrawerProps>((props, ref) => {
   }, [open, DrawerElement, preventFocus, handleCloseDrawer])
 
   useEffect(() => {
-    if (!open && drawerInitHeight) {
-      setDrawerHeight(drawerInitHeight)
-    }
-
+    setDrawerHeight(drawerInitHeight)
     setDrawerStartingHeight(drawerInitHeight)
   }, [open, drawerInitHeight])
 

--- a/packages/static/src/drawer/index.ts
+++ b/packages/static/src/drawer/index.ts
@@ -4,7 +4,12 @@ import DrawerHeader from './drawer-header'
 
 export type {DrawerFooterProps} from './drawer-footer'
 export type {DrawerHeaderProps} from './drawer-header'
-export type {DrawerDefaultProps, DrawerH5Props, DrawerProps} from './types'
+export type {
+  DrawerDefaultProps,
+  DrawerH5Props,
+  DrawerProps,
+  DrawerRef,
+} from './types'
 
 const Drawer = DrawerComposable as typeof DrawerComposable & {
   Header: typeof DrawerHeader

--- a/packages/static/src/drawer/styles/drawer-stories.module.css
+++ b/packages/static/src/drawer/styles/drawer-stories.module.css
@@ -6,7 +6,7 @@
     margin-block: 0 var(--cdg-spacing-2);
 
     &:not(:first-child) {
-      margin-top: var(--cdg-spacing-14);
+      margin-top: var(--cdg-spacing-8);
     }
   }
 
@@ -19,6 +19,11 @@
     display: flex;
     align-items: center;
     gap: var(--cdg-spacing-4);
+  }
+
+  & code {
+    font-family: monospace;
+    font-weight: var(--cdg-font-weight-semibold);
   }
 }
 
@@ -38,4 +43,39 @@
   & label + input[type='search'] {
     margin-left: var(--cdg-spacing-2);
   }
+}
+
+.drawerH5Example {
+  :global .drawer-expander {
+    background-color: var(--cdg-color-blueShades100);
+    padding: var(--cdg-spacing-2) var(--cdg-spacing-6);
+  }
+
+  :global .drawer-header {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--cdg-spacing-2);
+    padding-top: 0;
+    background-color: var(--cdg-color-blueShades100);
+
+    & > p {
+      margin: 0;
+      width: fit-content;
+      color: var(--cdg-color-grayShades10);
+    }
+  }
+}
+
+.previewCode {
+  padding: var(--cdg-spacing-2);
+  margin-bottom: var(--cdg-spacing-4);
+
+  width: 100%;
+  min-height: var(--cdg-spacing-5);
+  border-radius: var(--cdg-border-radius-lg);
+
+  background-color: var(--cdg-color-secondaryBg);
+  font-size: var(--cdg-font-size-label1);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }

--- a/packages/static/src/drawer/types.ts
+++ b/packages/static/src/drawer/types.ts
@@ -1,4 +1,4 @@
-import {DialogHTMLAttributes} from 'react'
+import {DialogHTMLAttributes, ReactNode} from 'react'
 
 type DrawerSharedProps = {
   /**
@@ -43,12 +43,26 @@ type DefaultDrawerProps = {
 
   expanderCSS?: never
   onExpandChange?: never
+  onHeightChange?: never
   expandedPoint?: never
   expandableLine?: never
   disableResize?: never
-  disableAddBodyAttr?: never
   disableDragClose?: never
 }
+
+type H5DrawerChildrenAsFunctionOptions = {
+  triggerCollapse: () => void
+  isExpanded: boolean
+  height: number
+} & Omit<
+  H5DrawerProps,
+  | 'variant'
+  | 'position'
+  | 'expanderCSS'
+  | 'onExpandChange'
+  | 'onHeightChange'
+  | 'children'
+>
 
 type H5DrawerProps = {
   variant: 'h5'
@@ -85,18 +99,6 @@ type H5DrawerProps = {
   disableResize?: boolean
 
   /**
-   * @deprecated This property now becomes useless, does nothing and will be removed in the next major release.
-   *
-   * Now respect the `<dialog />`'s default behaviors, let the browsers control if the content page below the Drawer should be rendered inert or not.
-   * ___
-   * @description
-   * if `true`, when open a drawer, it will NOT
-   *  add {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inert inert} attribute and `overflow: hidden` to the `<body>` tag.
-   * @default false
-   */
-  disableAddBodyAttr?: boolean
-
-  /**
    * Close the H5 drawer if the user drags and drops it below the default height.
    *
    * Note that if `disableResize` is true, users can't drag the the drawer.
@@ -104,6 +106,12 @@ type H5DrawerProps = {
    * @default false
    */
   disableDragClose?: boolean
+
+  onHeightChange?: (height: number) => void
+
+  children?:
+    | ReactNode
+    | ((options: H5DrawerChildrenAsFunctionOptions) => ReactNode)
 }
 
 export type DrawerH5Props = DrawerSharedProps & H5DrawerProps
@@ -117,3 +125,7 @@ export type DrawerProps = Props &
     DialogHTMLAttributes<HTMLDialogElement>,
     keyof Props | 'tabIndex' | 'autoFocus'
   >
+
+export type DrawerRef = HTMLDialogElement & {
+  triggerCollapse: () => void
+}

--- a/packages/static/src/index.ts
+++ b/packages/static/src/index.ts
@@ -89,6 +89,7 @@ export type {
   DrawerH5Props,
   DrawerHeaderProps,
   DrawerProps,
+  DrawerRef,
 } from './drawer'
 export {default as Dropdown} from './dropdown'
 export type {


### PR DESCRIPTION
## Description

**1) Changes**

- Remove the deprecated prop `disableAddBodyAttr`.
- Add `onHeightChange`.
- Add ability to pass children as function to H5 Drawer.
- Add `triggerCollapse()` function.

![Animation](https://github.com/comfortdelgro/compass-design/assets/142210010/6186083e-9fc8-411a-b014-ff70a80eaac5)


**2) Impact**

The Drawer component.

## Check list

- [x] 1. Did you start and verify your changes?
- [x] 2. Did you run build to make sure that your changes can be built successfully?
- [x] 3. No !important flag, inline style in css
- [x] 4. No boilerplate codes (1)
- [x] 5. No duplicate code that exist in common functions?
- [x] 6. All of defined variables should have default value, check null and undefined?
- [x] 7. Use meaningful name for variables, no suffix 1,2,... Describes reference information for easier to understand what's inside. (2)
- [x] 9. Unsubscribed all of subscribers and even listeners when you don't need them.

```
(1)
Boilerplate codes is duplicated multiple times a bunch of the same code. This should be a common function to reuse through your code or you can use generic class / methods or design pattern to avoid the Boilerplate codes.
```

```
(2)
Follow theo coding convention
NO acronym variable name:
WRONG: el, elm
RIGHT: element
Your code can be read as a sentence
```
