### PR TITLE
[NGPDCP-3246] PUDO - add clear button

### DIFF
--- a/apps/docs/data/components/pudo/PudoManipulation.tsx
+++ b/apps/docs/data/components/pudo/PudoManipulation.tsx
@@ -81,6 +81,7 @@ export default function PudoManipulationDocs() {
         removableLabel='Remove extra destination'
         minLength={2} // default value: 2
         maxLength={maxLength} // default value: 3
+        isClearable
       />
       {formValues && (
         <>

--- a/apps/docs/data/components/pudo/pudo.md
+++ b/apps/docs/data/components/pudo/pudo.md
@@ -13,7 +13,6 @@ components: PUDO
 import {Pudo} from '@comfortdelgro/react-compass'
 ```
 
-
 ## Usage
 
 ### Basic
@@ -48,22 +47,24 @@ This example is just for demo the swap, add & remove features. To prevent render
 
 ## Component Props
 
-Type: `PudoProps<TItemKeys extends string | number | symbol = string>`<sup>(1)</sup>
+Type: `PudoProps<TItemKeys extends PropertyKey = string>`<sup>(1)</sup>
 
-| Name             | Type                    | Default    | Description                                                                                                             |
-| :--------------- | :---------------------- | :--------- | :---------------------------------------------------------------------------------------------------------------------- |
-| `css`            | `CSS`                   | —          | The system prop that allows defining system overrides as well as additional CSS styles.                                 |
-| `items`\*        | `PudoItemProps[]`       | —          |                                                                                                                         |
-| `type`           | `"input"` \| `"custom"` | —          | If provided, this prop will override the `type` of all items.                                                           |
-| `onValuesChange` | `(values) => void`      | —          |                                                                                                                         |
-| `minLength`      | `number`                | `2`        | Minimum length of list items.                                                                                           |
-| `maxLength`      | `number`                | `3`        | Maximum length of list items.                                                                                           |
-| `addItems`       | `PudoItemProps[]`       | —          | Provide a items list to add to the existing item list.<br/><small>This list will be automatically deduplicated.</small> |
-| `addItemsLabel`  | `string`                | `"Add"`    | Label for the "add" button.                                                                                             |
-| `removableItems` | `TItemKeys[]`           | —          | A list of item name that allowed to remove.<br/><small>This list will be automatically deduplicated.</small>            |
-| `removableLabel` | `string`                | `"Remove"` | Label for the "remove" button.                                                                                          |
-| `compact`        | `"sm" \| "md"`          | —          | Compact size                                                                                                            |
-| `alignIcon`      | `"top"` \| `"center"`   | —          | If provided, this prop will override the `alignIcon` of all items.                                                      |
+| Name                | Type                                           | Default    | Description                                                                                                                 |
+| :------------------ | :--------------------------------------------- | :--------- | :-------------------------------------------------------------------------------------------------------------------------- |
+| `css`               | `CSS`                                          | —          | The system prop that allows defining system overrides as well as additional CSS styles.                                     |
+| `items`\*           | `PudoItemProps[]`                              | —          |                                                                                                                             |
+| `type`              | `"input"` \| `"custom"`                        | —          | If provided, this prop will override the `type` of all items.                                                               |
+| `onValuesChange`    | `(values: PudoValueChange<TItemKeys>) => void` | —          |                                                                                                                             |
+| `onItemFocusChange` | `(focusingItem?: TItemKeys) => void`           | —          | `focusingItem` is the name of the focused item.<br/><small>If no items are focusing, the value will be `undefined`.</small> |
+| `minLength`         | `number`                                       | `2`        | Minimum length of list items.                                                                                               |
+| `maxLength`         | `number`                                       | `3`        | Maximum length of list items.                                                                                               |
+| `addItems`          | `PudoItemProps[]`                              | —          | Provide a items list to add to the existing item list.<br/><small>This list will be automatically deduplicated.</small>     |
+| `addItemsLabel`     | `string`                                       | `"Add"`    | Label for the "add" button.                                                                                                 |
+| `removableItems`    | `TItemKeys[]`                                  | —          | A list of item name that allowed to remove.<br/><small>This list will be automatically deduplicated.</small>                |
+| `removableLabel`    | `string`                                       | `"Remove"` | Label for the "remove" button.                                                                                              |
+| `compact`           | `"sm" \| "md"`                                 | —          | Compact size                                                                                                                |
+| `alignIcon`         | `"top"` \| `"center"`                          | —          | If provided, this prop will override the `alignIcon` of all items.                                                          |
+| `isClearable`       | `boolean`                                      | —          | If provided, this prop will override the `isClearable` of all items.                                                        |
 
 ### `PudoItemProps`
 
@@ -80,6 +81,15 @@ Type: `PudoProps<TItemKeys extends string | number | symbol = string>`<sup>(1)</
 | `content`     | `ReactNode`                  | —                                        | Content, description, etc,... for the `custom` item type.                                         |
 | `maxLength`   | `number`                     | `255`                                    | Maximum characters.                                                                               |
 | `isRequired`  | `boolean`                    | `false`                                  | Required state.                                                                                   |
+| `isClearable` | `boolean`                    | `false`                                  | Add clear value button for each input field.                                                      |
+
+### `PudoValueChange`
+
+| Name                               | Type                         | Default | Description                                                                                                                                                                         |
+| :--------------------------------- | :--------------------------- | :------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`\*                           | Inference type<sup>(1)</sup> | —       | Same order and name as Pudo's`items` props.<br/>Item Key and also is input's `name` attribute.                                                                                      |
+| `value`                            | `string`                     | `""`    | Input's value.                                                                                                                                                                      |
+| <code><del>isFocusing</del></code> | `boolean`                    | `false` | Focus status of each items.<br/><small>Deprecated and will be removed on next major release.<br/>To track item's focus status, consider using `onFocusChange` prop instead.</small> |
 
 \*: Required.
 

--- a/packages/react-compass/src/pudo/hooks/useStateWithCallback.ts
+++ b/packages/react-compass/src/pudo/hooks/useStateWithCallback.ts
@@ -1,0 +1,37 @@
+import {SetStateAction, useCallback, useEffect, useRef, useState} from 'react'
+
+type CallBackType<T> = (updatedValue: T) => void
+
+type UseStateWithCallbackReturnType = <T>(
+  initialValue: T | (() => T),
+) => [T, (newValue: SetStateAction<T>, callback?: CallBackType<T>) => void]
+
+/**
+ * @deprecated when `isFocusing` is removed from `PudoValueChange`,
+ * no need to prevent batching `arrPudoValues` state updates anymore.
+ *
+ * @todo Remove this hook when `isFocusing` is removed from `PudoValueChange`.
+ */
+export const useStateWithCallback: UseStateWithCallbackReturnType = <T>(
+  initialValue: T | (() => T),
+) => {
+  const [state, _setState] = useState<T>(initialValue)
+  const callbackQueue = useRef<Array<CallBackType<T>>>([])
+
+  const setState = useCallback(
+    (newValue: SetStateAction<T>, callback?: CallBackType<T>) => {
+      _setState(newValue)
+      if (callback && typeof callback === 'function') {
+        callbackQueue.current.push(callback)
+      }
+    },
+    [],
+  )
+
+  useEffect(() => {
+    callbackQueue.current.forEach((cb) => cb(state))
+    callbackQueue.current = []
+  }, [state])
+
+  return [state, setState]
+}

--- a/packages/react-compass/src/pudo/pudo-item.tsx
+++ b/packages/react-compass/src/pudo/pudo-item.tsx
@@ -1,10 +1,11 @@
-import React, {useCallback, useMemo} from 'react'
+import React, {useCallback, useMemo, useRef} from 'react'
+import Button from '../button'
 import TextField from '../textfield'
 import {DefaultIcons} from './pudo.config'
 import {StyledPUDOItem} from './pudo.styles'
 import {PudoItemPrivateProps} from './pudo.types'
 
-const PudoItem = <TItemName extends string | number | symbol>({
+const PudoItem = <TItemName extends PropertyKey>({
   index,
   itemsLength,
   name,
@@ -26,17 +27,25 @@ const PudoItem = <TItemName extends string | number | symbol>({
   isRequired = false,
   alignIcon = 'center',
   compact,
+  isClearable = false,
 }: PudoItemPrivateProps<TItemName>) => {
+  const inputRef = useRef<HTMLInputElement>(null)
   const pudoItemCSS = useMemo(
     () => ({...css, zIndex: itemsLength - 1 - index ?? undefined}),
     [css, index, itemsLength],
   )
+
+  const handleClearInput = useCallback(() => {
+    onValueChange?.('')
+    inputRef.current?.focus()
+  }, [onValueChange])
 
   const renderPudoContent = useCallback(() => {
     switch (type) {
       case 'input':
         return (
           <TextField
+            inputRef={inputRef}
             className='cdg-pudo-item__input'
             css={{
               '& > div': {
@@ -53,6 +62,9 @@ const PudoItem = <TItemName extends string | number | symbol>({
                   fontWeight: '$normal',
                 },
               },
+              '.right-icon': {
+                marginRight: 0,
+              },
             }}
             type='text'
             name={name.toString()}
@@ -62,6 +74,38 @@ const PudoItem = <TItemName extends string | number | symbol>({
             placeholder={placeholder}
             maxLength={maxLength}
             isRequired={isRequired}
+            rightIcon={
+              <Button
+                css={{
+                  padding: 0,
+                  width: '$6',
+                  height: '$6',
+                  '.children > svg': {
+                    width: '$4',
+                    height: '$4',
+                  },
+                  ...(!value || !isClearable ? {display: 'none'} : undefined),
+                }}
+                className='cdg-pudo-item__input-btn-clear'
+                variant='ghost'
+                type='button'
+                onClick={() => handleClearInput()}
+                aria-label='Clear input'
+              >
+                <svg
+                  xmlns='http://www.w3.org/2000/svg'
+                  width='16'
+                  height='16'
+                  viewBox='0 0 16 16'
+                  fill='none'
+                >
+                  <path
+                    d='M7.29289 5.73746C7.68342 6.12798 8.31658 6.12798 8.70711 5.73746L12.7376 1.70698C13.1281 1.31646 13.7613 1.31646 14.1518 1.70699L14.2929 1.84808C14.6834 2.23861 14.6834 2.87177 14.2929 3.2623L10.2624 7.29277C9.87189 7.68329 9.87189 8.31646 10.2624 8.70698L14.2929 12.7375C14.6834 13.128 14.6834 13.7612 14.2929 14.1517L14.1518 14.2928C13.7613 14.6833 13.1281 14.6833 12.7376 14.2928L8.70711 10.2623C8.31658 9.87177 7.68342 9.87177 7.29289 10.2623L3.26242 14.2928C2.87189 14.6833 2.23873 14.6833 1.8482 14.2928L1.70711 14.1517C1.31658 13.7611 1.31658 13.128 1.70711 12.7375L5.73758 8.70698C6.12811 8.31646 6.12811 7.6833 5.73758 7.29277L1.70711 3.2623C1.31658 2.87177 1.31658 2.23861 1.70711 1.84808L1.8482 1.70698C2.23873 1.31646 2.87189 1.31646 3.26242 1.70698L7.29289 5.73746Z'
+                    fill='#B4B4B4'
+                  />
+                </svg>
+              </Button>
+            }
           />
         )
 

--- a/packages/react-compass/src/pudo/pudo.stories.tsx
+++ b/packages/react-compass/src/pudo/pudo.stories.tsx
@@ -103,6 +103,7 @@ export function Default() {
         css={{marginBlock: '$4'}}
         items={exampleItems}
         onValuesChange={debounceUpdate}
+        isClearable
       />
       <Button size='sm' css={{marginBottom: '$4'}} onClick={handleAddLocation}>
         Update first item
@@ -129,6 +130,7 @@ export function Default() {
         removableLabel='Remove extra destination'
         minLength={2} // default value
         maxLength={3} // default value
+        isClearable
       />
       {formValues && (
         <PreviewCode>{JSON.stringify(formValues, null, 2)}</PreviewCode>

--- a/packages/react-compass/src/pudo/pudo.types.ts
+++ b/packages/react-compass/src/pudo/pudo.types.ts
@@ -1,15 +1,20 @@
-import {CSSProperties, FocusEvent, ReactNode} from 'react'
+import {CSSProperties, FocusEventHandler, ReactNode} from 'react'
 import {StyledComponentProps} from '../utils/stitches.types'
 
-export type PudoValueChange<
-  TItemKeys extends string | number | symbol = string,
-> = Array<{
+export type PudoValueChange<TItemKeys extends PropertyKey = string> = Array<{
   name: TItemKeys
   value: string
+  /**
+   * @deprecated `isFocusing` will be removed on next major release (`@comfortdelgro/react-compass@4.x`)
+   *
+   * Why? **Bad decision!** Tracking focus status should be seperated from `onValuesChange`.
+   * ___
+   * `isFocusing` still works as expected but consider using `onFocusChange` prop instead to track item's focus status.
+   */
   isFocusing?: boolean
 }>
 
-export type PudoProps<TItemKeys extends string | number | symbol> = {
+export type PudoProps<TItemKeys extends PropertyKey> = {
   className?: string
   style?: CSSProperties
   /**
@@ -19,6 +24,11 @@ export type PudoProps<TItemKeys extends string | number | symbol> = {
    */
   items: Readonly<Array<PudoItemProps<TItemKeys>>>
   onValuesChange?: (values: PudoValueChange<TItemKeys>) => void
+  /**
+   * @param focusingItem the name of the focused item.
+   * If no items are focusing, the value will be `undefined`.
+   */
+  onItemFocusChange?: (focusingItem?: TItemKeys) => void
   /**
    * This will override the `type` of all items.
    */
@@ -70,6 +80,8 @@ export type PudoProps<TItemKeys extends string | number | symbol> = {
    * `bgColor` will be ignored if `data-background` is provided.
    */
   bgColor?: string
+  /** if provided, `isClearable` of all items will be overwritten */
+  isClearable?: boolean | undefined
 
   /**
    * ~ `[data-*]` - any data attributes are accepted.
@@ -81,7 +93,7 @@ export type PudoProps<TItemKeys extends string | number | symbol> = {
   [key: `data-${string}`]: string
 } & StyledComponentProps
 
-export type PudoItemProps<TName extends string | number | symbol = string> = {
+export type PudoItemProps<TName extends PropertyKey = string> = {
   name: TName
   className?: string
   icon?: ReactNode
@@ -99,24 +111,23 @@ export type PudoItemProps<TName extends string | number | symbol = string> = {
   title?: ReactNode
   /** `content` is used for `'custom'` type item. */
   content?: ReactNode
-
   /** @default false */
   allowSwap?: boolean
-
   /** @default 255 */
   maxLength?: number
-
+  /** @default false */
   isRequired?: boolean
-
   /** @default "center" */
   alignIcon?: 'top' | 'center' | undefined
+  /** @default false */
+  isClearable?: boolean | undefined
 } & StyledComponentProps
 
-export type PudoItemPrivateProps<TName extends string | number | symbol> = {
+export type PudoItemPrivateProps<TName extends PropertyKey> = {
   index: number
   itemsLength: number
   compact?: PudoProps<TName>['compact']
   onValueChange?: (value: string) => void
   handleSwap?: () => void
-  onInputFocus?: (e: FocusEvent<HTMLInputElement>) => void
+  onInputFocus?: FocusEventHandler<HTMLInputElement>
 } & PudoItemProps<TName>

--- a/packages/static/src/pudo/hooks/useStateWithCallback.ts
+++ b/packages/static/src/pudo/hooks/useStateWithCallback.ts
@@ -1,0 +1,37 @@
+import {SetStateAction, useCallback, useEffect, useRef, useState} from 'react'
+
+type CallBackType<T> = (updatedValue: T) => void
+
+type UseStateWithCallbackReturnType = <T>(
+  initialValue: T | (() => T),
+) => [T, (newValue: SetStateAction<T>, callback?: CallBackType<T>) => void]
+
+/**
+ * @deprecated when `isFocusing` is removed from `PudoValueChange`,
+ * no need to prevent batching `arrPudoValues` state updates anymore.
+ *
+ * @todo Remove this hook when `isFocusing` is removed from `PudoValueChange`.
+ */
+export const useStateWithCallback: UseStateWithCallbackReturnType = <T>(
+  initialValue: T | (() => T),
+) => {
+  const [state, _setState] = useState<T>(initialValue)
+  const callbackQueue = useRef<Array<CallBackType<T>>>([])
+
+  const setState = useCallback(
+    (newValue: SetStateAction<T>, callback?: CallBackType<T>) => {
+      _setState(newValue)
+      if (callback && typeof callback === 'function') {
+        callbackQueue.current.push(callback)
+      }
+    },
+    [],
+  )
+
+  useEffect(() => {
+    callbackQueue.current.forEach((cb) => cb(state))
+    callbackQueue.current = []
+  }, [state])
+
+  return [state, setState]
+}

--- a/packages/static/src/pudo/pudo-item.tsx
+++ b/packages/static/src/pudo/pudo-item.tsx
@@ -1,11 +1,12 @@
 import clsx from 'clsx'
-import {memo} from 'react'
+import {memo, useCallback, useRef} from 'react'
+import {Button} from '..'
 import TextField from '../textfield'
 import {DefaultIcons} from './pudo.config'
 import {PudoItemPrivateProps} from './pudo.types'
 import classes from './styles/pudo.module.css'
 
-const PudoItemComponent = <TItemName extends string | number | symbol>({
+const PudoItemComponent = <TItemName extends PropertyKey>({
   index,
   itemsLength,
   name,
@@ -26,12 +27,21 @@ const PudoItemComponent = <TItemName extends string | number | symbol>({
   isRequired = false,
   alignIcon = 'center',
   compact,
+  isClearable = false,
 }: PudoItemPrivateProps<TItemName>) => {
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const handleClearInput = useCallback(() => {
+    onValueChange?.('')
+    inputRef.current?.focus()
+  }, [onValueChange])
+
   const renderPudoContent = () => {
     switch (type) {
       case 'input':
         return (
           <TextField
+            inputRef={inputRef}
             className={clsx(classes.pudoItemInput, 'cdg-pudo-item__input')}
             type='text'
             name={name.toString()}
@@ -41,6 +51,34 @@ const PudoItemComponent = <TItemName extends string | number | symbol>({
             placeholder={placeholder}
             maxLength={maxLength}
             isRequired={isRequired}
+            rightIcon={
+              <Button
+                className={clsx(
+                  classes.pudoItemInputBtnClear,
+                  'cdg-pudo-item__input-btn-clear',
+                  !value || !isClearable
+                    ? classes.pudoItemInputBtnClearHidden
+                    : '',
+                )}
+                variant='ghost'
+                type='button'
+                onClick={() => handleClearInput()}
+                aria-label='Clear input'
+              >
+                <svg
+                  xmlns='http://www.w3.org/2000/svg'
+                  width='16'
+                  height='16'
+                  viewBox='0 0 16 16'
+                  fill='none'
+                >
+                  <path
+                    d='M7.29289 5.73746C7.68342 6.12798 8.31658 6.12798 8.70711 5.73746L12.7376 1.70698C13.1281 1.31646 13.7613 1.31646 14.1518 1.70699L14.2929 1.84808C14.6834 2.23861 14.6834 2.87177 14.2929 3.2623L10.2624 7.29277C9.87189 7.68329 9.87189 8.31646 10.2624 8.70698L14.2929 12.7375C14.6834 13.128 14.6834 13.7612 14.2929 14.1517L14.1518 14.2928C13.7613 14.6833 13.1281 14.6833 12.7376 14.2928L8.70711 10.2623C8.31658 9.87177 7.68342 9.87177 7.29289 10.2623L3.26242 14.2928C2.87189 14.6833 2.23873 14.6833 1.8482 14.2928L1.70711 14.1517C1.31658 13.7611 1.31658 13.128 1.70711 12.7375L5.73758 8.70698C6.12811 8.31646 6.12811 7.6833 5.73758 7.29277L1.70711 3.2623C1.31658 2.87177 1.31658 2.23861 1.70711 1.84808L1.8482 1.70698C2.23873 1.31646 2.87189 1.31646 3.26242 1.70698L7.29289 5.73746Z'
+                    fill='#B4B4B4'
+                  />
+                </svg>
+              </Button>
+            }
           />
         )
 

--- a/packages/static/src/pudo/pudo.stories.tsx
+++ b/packages/static/src/pudo/pudo.stories.tsx
@@ -123,6 +123,7 @@ export function Default() {
         removableLabel='Remove extra destination'
         minLength={2} // default value
         maxLength={3} // default value
+        isClearable
       />
       {formValues && (
         <pre className={classes.previewCode}>

--- a/packages/static/src/pudo/pudo.types.ts
+++ b/packages/static/src/pudo/pudo.types.ts
@@ -1,14 +1,19 @@
-import {CSSProperties, FocusEvent, ReactNode} from 'react'
+import {CSSProperties, FocusEventHandler, ReactNode} from 'react'
 
-export type PudoValueChange<
-  TItemKeys extends string | number | symbol = string,
-> = Array<{
+export type PudoValueChange<TItemKeys extends PropertyKey = string> = Array<{
   name: TItemKeys
   value: string
+  /**
+   * @deprecated `isFocusing` will be removed on next major release (`@comfortdelgro/react-compass@4.x`)
+   *
+   * Why? **Bad decision!** Tracking focus status should be seperated from `onValuesChange`.
+   * ___
+   * `isFocusing` still works as expected but consider using `onFocusChange` prop instead to track item's focus status.
+   */
   isFocusing?: boolean
 }>
 
-export type PudoProps<TItemKeys extends string | number | symbol> = {
+export type PudoProps<TItemKeys extends PropertyKey> = {
   className?: string
   css?: unknown
   style?: CSSProperties
@@ -19,6 +24,11 @@ export type PudoProps<TItemKeys extends string | number | symbol> = {
    */
   items: Readonly<Array<PudoItemProps<TItemKeys>>>
   onValuesChange?: (values: PudoValueChange<TItemKeys>) => void
+  /**
+   * @param focusingItem the input name of the focused item.
+   * If no items are focusing, the value will be `undefined`.
+   */
+  onItemFocusChange?: (focusingItem?: TItemKeys) => void
   /**
    * This will override the `type` of all items.
    */
@@ -70,6 +80,8 @@ export type PudoProps<TItemKeys extends string | number | symbol> = {
    * `bgColor` will be ignored if `data-background` is provided.
    */
   bgColor?: string
+  /** if provided, `isClearable` of all items will be overwritten */
+  isClearable?: boolean
 
   /**
    * ~ `[data-*]` - any data attributes are accepted.
@@ -81,7 +93,7 @@ export type PudoProps<TItemKeys extends string | number | symbol> = {
   [key: `data-${string}`]: string
 }
 
-export type PudoItemProps<TName extends string | number | symbol = string> = {
+export type PudoItemProps<TName extends PropertyKey = string> = {
   name: TName
   className?: string
   icon?: ReactNode
@@ -99,23 +111,23 @@ export type PudoItemProps<TName extends string | number | symbol = string> = {
   title?: ReactNode
   /** `content` is used for `'custom'` type item. */
   content?: ReactNode
-
   /** @default false */
   allowSwap?: boolean
-
   /** @default 255 */
   maxLength?: number
-
+  /** @default false */
   isRequired?: boolean
   /** @default "center" */
   alignIcon?: 'top' | 'center'
+  /** @default false */
+  isClearable?: boolean
 }
 
-export type PudoItemPrivateProps<TName extends string | number | symbol> = {
+export type PudoItemPrivateProps<TName extends PropertyKey> = {
   index: number
   itemsLength: number
   compact?: PudoProps<TName>['compact']
   onValueChange?: (value: string) => void
   handleSwap?: () => void
-  onInputFocus?: (e: FocusEvent<HTMLInputElement>) => void
+  onInputFocus?: FocusEventHandler<HTMLInputElement>
 } & PudoItemProps<TName>

--- a/packages/static/src/pudo/styles/pudo.module.css
+++ b/packages/static/src/pudo/styles/pudo.module.css
@@ -257,6 +257,23 @@
 
       --_cdg-pudo-icon-shape-bg: var(--cdg-color-grayShades10);
     }
+
+    :global(.cdg-textfield-right-icon) {
+      margin-right: 0;
+    }
+
+    .pudoItemInputBtnClear {
+      width: var(--cdg-spacing-6);
+      height: var(--cdg-spacing-6);
+
+      & svg {
+        display: block;
+      }
+
+      &.pudoItemInputBtnClearHidden {
+        display: none;
+      }
+    }
   }
 
   .pudoItem.custom {
@@ -294,6 +311,10 @@
 }
 
 @layer compoundVariant {
+  .pudoItem.input .pudoItemInputBtnClear:global(> .cdg-button-content) {
+    padding: 0;
+  }
+
   .pudoItem.alignIcon--center:is(.sm, .md) {
     .pudoItemIcon:before {
       top: calc(var(--cdg-pudo-dot-size) * -1);


### PR DESCRIPTION
## Description

**1) Changes**

PUDO input type:
- Add the ability to show a clear button. Related to [NGPDCP-3246](https://comfortdelgrotaxi.atlassian.net/browse/NGPDCP-3246). 
![image](https://github.com/comfortdelgro/compass-design/assets/142210010/bbe3c1fb-9cde-4606-aed2-9196ca05359d)

- Introducing `onItemFocusChange` that helps us track PUDO input items' focus state status.
- `isFocusing` in `onValuesChange` now is deprecated and no longer recommended for use.

**2) Impact**

The PUDO component

## Check list

- [x] 1. Did you start and verify your changes?
- [x] 2. Did you run build to make sure that your changes can be built successfully?
- [x] 3. No !important flag, inline style in css
- [x] 4. No boilerplate codes (1)
- [x] 5. No duplicate code that exist in common functions?
- [x] 6. All of defined variables should have default value, check null and undefined?
- [x] 7. Use meaningful name for variables, no suffix 1,2,... Describes reference information for easier to understand what's inside. (2)
- [x] 9. Unsubscribed all of subscribers and even listeners when you don't need them.

```
(1)
Boilerplate codes is duplicated multiple times a bunch of the same code. This should be a common function to reuse through your code or you can use generic class / methods or design pattern to avoid the Boilerplate codes.
```

```
(2)
Follow theo coding convention
NO acronym variable name:
WRONG: el, elm
RIGHT: element
Your code can be read as a sentence
```


[NGPDCP-3246]: https://comfortdelgrotaxi.atlassian.net/browse/NGPDCP-3246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ