### PR TITLE
fix: Drawer - `preventFocus` correction

### DIFF
--- a/apps/docs/data/components/drawer/DrawerCustomize.tsx
+++ b/apps/docs/data/components/drawer/DrawerCustomize.tsx
@@ -132,7 +132,7 @@ export default function DrawerCustomizeDocs() {
           onClick={() =>
             setOpenNoFocusDrawer({
               open: true,
-              preventFocus: true,
+              preventFocus: false,
             })
           }
         >
@@ -144,7 +144,7 @@ export default function DrawerCustomizeDocs() {
           onClick={() =>
             setOpenNoFocusDrawer({
               open: true,
-              preventFocus: false,
+              preventFocus: true,
             })
           }
         >

--- a/packages/react-compass/src/drawer/drawer.stories.tsx
+++ b/packages/react-compass/src/drawer/drawer.stories.tsx
@@ -149,7 +149,7 @@ export function H5() {
         onClick={() =>
           setOpenNoFocusDrawer({
             open: true,
-            preventFocus: true,
+            preventFocus: false,
           })
         }
       >
@@ -161,7 +161,7 @@ export function H5() {
         onClick={() =>
           setOpenNoFocusDrawer({
             open: true,
-            preventFocus: false,
+            preventFocus: true,
           })
         }
       >

--- a/packages/react-compass/src/drawer/drawer.tsx
+++ b/packages/react-compass/src/drawer/drawer.tsx
@@ -35,7 +35,7 @@ const Drawer = forwardRef<DrawerRef, DrawerProps>((props, ref) => {
     open = false,
     onClose,
     onMouseDown,
-    preventFocus = true,
+    preventFocus = false,
     preventClose = false,
 
     variant = 'default',
@@ -269,7 +269,7 @@ const Drawer = forwardRef<DrawerRef, DrawerProps>((props, ref) => {
     }
 
     if (open) {
-      if (!preventFocus) {
+      if (preventFocus) {
         DrawerElement.setAttribute('inert', '')
       }
 

--- a/packages/static/src/drawer/Drawer.stories.tsx
+++ b/packages/static/src/drawer/Drawer.stories.tsx
@@ -393,7 +393,7 @@ export function H5() {
         onClick={() =>
           setOpenNoFocusDrawer({
             open: true,
-            preventFocus: true,
+            preventFocus: false,
           })
         }
       >
@@ -405,7 +405,7 @@ export function H5() {
         onClick={() =>
           setOpenNoFocusDrawer({
             open: true,
-            preventFocus: false,
+            preventFocus: true,
           })
         }
       >

--- a/packages/static/src/drawer/drawer.tsx
+++ b/packages/static/src/drawer/drawer.tsx
@@ -37,7 +37,7 @@ const Drawer = forwardRef<DrawerRef, DrawerProps>((props, ref) => {
     open = false,
     onClose,
     onMouseDown,
-    preventFocus = true,
+    preventFocus = false,
     preventClose = false,
 
     variant = 'default',
@@ -271,7 +271,7 @@ const Drawer = forwardRef<DrawerRef, DrawerProps>((props, ref) => {
     }
 
     if (open) {
-      if (!preventFocus) {
+      if (preventFocus) {
         DrawerElement.setAttribute('inert', '')
       }
       drawerMode === 'modal' ? DrawerElement.showModal() : DrawerElement.show()


### PR DESCRIPTION
## Description

**1) Root cause**

The default value of `preventFocus` should be `false`, as stated in the documentation.

**2) Impact**

The Drawer component.

## Check list

- [x] 1. Did you start and verify your changes?
- [x] 2. Did you run build to make sure that your changes can be built successfully?
- [x] 3. No !important flag, inline style in css
- [x] 4. No boilerplate codes (1)
- [x] 5. No duplicate code that exist in common functions?
- [x] 6. All of defined variables should have default value, check null and undefined?
- [x] 7. Use meaningful name for variables, no suffix 1,2,... Describes reference information for easier to understand what's inside. (2)
- [x] 9. Unsubscribed all of subscribers and even listeners when you don't need them.

```
(1)
Boilerplate codes is duplicated multiple times a bunch of the same code. This should be a common function to reuse through your code or you can use generic class / methods or design pattern to avoid the Boilerplate codes.
```

```
(2)
Follow theo coding convention
NO acronym variable name:
WRONG: el, elm
RIGHT: element
Your code can be read as a sentence
```
